### PR TITLE
Make publication tiles clickable on publications archive

### DIFF
--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -15,7 +15,8 @@
 <div class="{{ include.type | default: "list" }}__item">
   <article class="archive__item{% if post.collection == 'publications' and post.url %} archive__item--linked{% endif %}" itemscope itemtype="http://schema.org/CreativeWork">
     {% if post.collection == 'publications' and post.url %}
-      <a class="archive__item-link" href="{{ base_path }}{{ post.url }}" aria-label="Open publication details"></a>
+      {% assign publication_link_label = post.title | default: post.citation | strip_html | strip %}
+      <a class="archive__item-link" href="{{ base_path }}{{ post.url }}" aria-label="Open publication details for {{ publication_link_label | escape }}"></a>
     {% endif %}
     {% if include.type == "grid" and teaser %}
       <div class="archive__item-teaser">

--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -13,7 +13,10 @@
 {% endif %}
 
 <div class="{{ include.type | default: "list" }}__item">
-  <article class="archive__item" itemscope itemtype="http://schema.org/CreativeWork">
+  <article class="archive__item{% if post.collection == 'publications' and post.url %} archive__item--linked{% endif %}" itemscope itemtype="http://schema.org/CreativeWork">
+    {% if post.collection == 'publications' and post.url %}
+      <a class="archive__item-link" href="{{ base_path }}{{ post.url }}" aria-label="Open publication details"></a>
+    {% endif %}
     {% if include.type == "grid" and teaser %}
       <div class="archive__item-teaser">
         <img src=

--- a/_sass/_archive.scss
+++ b/_sass/_archive.scss
@@ -74,6 +74,26 @@
   }
 }
 
+
+.archive__item {
+  position: relative;
+}
+
+.archive__item--linked {
+  cursor: pointer;
+}
+
+.archive__item-link {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
+
+.archive__item--linked a:not(.archive__item-link) {
+  position: relative;
+  z-index: 2;
+}
+
 .archive__item:hover {
   .archive__item-teaser {
     box-shadow: 0 0 10px rgba(#000, 0.25);


### PR DESCRIPTION
### Motivation
- Make publication tiles on the publications archive act as full-card links to their single-publication pages for easier navigation.
- Preserve existing inline links (download/permalink) so nested actionable elements remain usable.

### Description
- Updated `_includes/archive-single.html` to add an `archive__item--linked` class for items in the `publications` collection and to insert an absolute-positioned overlay anchor that links to `{{ post.url }}`.
- Added scoped styles to `_sass/_archive.scss` to set `.archive__item { position: relative; }`, provide a full-cover `.archive__item-link { position: absolute; inset: 0; z-index: 1; }`, show `cursor: pointer` for linked tiles, and lift nested links with `.archive__item--linked a:not(.archive__item-link) { z-index: 2; }` so they remain clickable.
- Kept the existing title/permalink markup unchanged so permalinks and external links continue to work as before.

### Testing
- Ran `bundle exec jekyll build`, which failed because the `jekyll` executable is not available in this environment (test failed).
- Ran `bundle install`, which failed due to network access to `rubygems.org` returning `403 Forbidden` (test failed).
- Attempted a Playwright navigation/screenshot of `http://127.0.0.1:4000/publications/`, which failed with `ERR_EMPTY_RESPONSE` because no local site server was running (test failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991baad4fac83309ff8db9de61a7239)