### PR TITLE
Add publication pages for OJ6 and OC42–OC54

### DIFF
--- a/_publications/2024-06-01-OC42.md
+++ b/_publications/2024-06-01-OC42.md
@@ -1,0 +1,18 @@
+---
+title: "Infrastructure Optimization for Predictive Maintenance: Enhanced Backend and Artificial Intelligence Integration"
+authors: "Stern, M., Hallmann, M., Vona, F., Franke, U., Ostertag, T., Schlüter, B. & Voigt-Antons, J.-N."
+collection: publications
+category: "conferences"
+permalink: /publication/2024-06-01-OC42
+excerpt: 'We present a modular backend architecture for predictive maintenance that streamlines data ingestion, labeling, and model deployment while supporting human-in-the-loop workflows. The system integrates scalable storage, message queues, and inference services with UI components for anomaly review. Benchmarks from an industrial pilot show reduced latency, improved data quality, and faster iteration on AI models.'
+date: 2024-06-01
+venue: 'Paper presented at the International Conference on Human-Computer Interaction (HCII 2024), Washington DC, USA, June 2024'
+paperurl: 'https://doi.org/10.1007/978-3-031-78531-3_30'
+citation: 'Stern, M., Hallmann, M., Vona, F., Franke, U., Ostertag, T., Schlüter, B. &amp; Voigt-Antons, J.-N. (2024, June). Infrastructure Optimization for Predictive Maintenance: Enhanced Backend and Artificial Intelligence Integration. Paper presented at the International Conference on Human-Computer Interaction (HCII 2024). Washington DC, USA. https://doi.org/10.1007/978-3-031-78531-3_30'
+---
+
+<a href='https://doi.org/10.1007/978-3-031-78531-3_30'>Download publication here.</a>
+
+We present a modular backend architecture for predictive maintenance that streamlines data ingestion, labeling, and model deployment while supporting human-in-the-loop workflows. The system integrates scalable storage, message queues, and inference services with UI components for anomaly review. Benchmarks from an industrial pilot show reduced latency, improved data quality, and faster iteration on AI models.
+
+Recommended citation: Stern, M., Hallmann, M., Vona, F., Franke, U., Ostertag, T., Schlüter, B. & Voigt-Antons, J.-N. (2024, June). Infrastructure Optimization for Predictive Maintenance: Enhanced Backend and Artificial Intelligence Integration. Paper presented at the International Conference on Human-Computer Interaction (HCII 2024). Washington DC, USA. https://doi.org/10.1007/978-3-031-78531-3_30

--- a/_publications/2024-09-01-OC43.md
+++ b/_publications/2024-09-01-OC43.md
@@ -1,0 +1,18 @@
+---
+title: "What importance does outpatient care have for mobility in rural areas? Results from a GPS study among persons aged 75 and older"
+authors: "Haeger, C., Mümken, S., Spang, R. P., Brauer, M., Voigt-Antons, J.N. & Gellert, P."
+collection: publications
+category: "conferences"
+permalink: /publication/2024-09-01-OC43
+excerpt: 'This contribution analyzes GPS-based mobility patterns of rural residents aged 75+ to examine how outpatient care availability relates to out-of-home activity. We quantify trip frequency, distances, and destinations and model associations with local care infrastructure. Findings suggest that accessible outpatient services can enable broader mobility and social participation, informing regional planning and age-friendly care models.'
+date: 2024-09-01
+venue: 'Paper presented at the 23. Deutscher Kongress für Versorgungsforschung 2024, Potsdam, Germany, September 2024'
+paperurl: 'https://doi.org/10.1007/s00103-024-03917-2'
+citation: 'Haeger, C., Mümken, S., Spang, R. P., Brauer, M., Voigt-Antons, J.N. &amp; Gellert, P. (2024, September). What importance does outpatient care have for mobility in rural areas? Results from a GPS study among persons aged 75 and older. Paper presented at the 23. Deutscher Kongress für Versorgungsforschung 2024. Potsdam, Germany.'
+---
+
+<a href='https://doi.org/10.1007/s00103-024-03917-2'>Download publication here.</a>
+
+This contribution analyzes GPS-based mobility patterns of rural residents aged 75+ to examine how outpatient care availability relates to out-of-home activity. We quantify trip frequency, distances, and destinations and model associations with local care infrastructure. Findings suggest that accessible outpatient services can enable broader mobility and social participation, informing regional planning and age-friendly care models.
+
+Recommended citation: Haeger, C., Mümken, S., Spang, R. P., Brauer, M., Voigt-Antons, J.N. & Gellert, P. (2024, September). What importance does outpatient care have for mobility in rural areas? Results from a GPS study among persons aged 75 and older. Paper presented at the 23. Deutscher Kongress für Versorgungsforschung 2024. Potsdam, Germany.

--- a/_publications/2025-01-01-OJ6.md
+++ b/_publications/2025-01-01-OJ6.md
@@ -1,0 +1,18 @@
+---
+title: "Using promising technologies in clinical-psychological diagnostics: Focus auf KI und XR"
+authors: "Kuhlencord, M., Ohse, J., Fox, J., Peperkorn, N., Rätsch, M., Voigt-Antons, J.-N. & Shiban, Y."
+collection: publications
+category: "manuscripts"
+permalink: /publication/2025-01-01-OJ6
+excerpt: 'This article explores the use of artificial intelligence (AI) and extended reality (XR) in clinical-psychological diagnostics. It discusses both the opportunities and challenges of integrating these innovative technologies into diagnostic practice, with a focus on improving assessment accuracy and patient experience. The paper emphasizes the importance of interdisciplinary research to ensure effective and ethically responsible applications.'
+date: 2025-01-01
+venue: 'Published in <i>Psychologie in Österreich</i>, 2025'
+paperurl: 'http://dx.doi.org/10.2196/30621'
+citation: 'Kuhlencord, M., Ohse, J., Fox, J., Peperkorn, N., Rätsch, M., Voigt-Antons, J.-N. &amp; Shiban, Y. (2025). Using promising technologies in clinical-psychological diagnostics: Focus auf KI und XR Focus auf KI und XR. Psychologie in Österreich, (4 &amp; 5), 278-285.'
+---
+
+<a href='http://dx.doi.org/10.2196/30621'>Download publication here.</a>
+
+This article explores the use of artificial intelligence (AI) and extended reality (XR) in clinical-psychological diagnostics. It discusses both the opportunities and challenges of integrating these innovative technologies into diagnostic practice, with a focus on improving assessment accuracy and patient experience. The paper emphasizes the importance of interdisciplinary research to ensure effective and ethically responsible applications.
+
+Recommended citation: Kuhlencord, M., Ohse, J., Fox, J., Peperkorn, N., Rätsch, M., Voigt-Antons, J.-N. & Shiban, Y. (2025). Using promising technologies in clinical-psychological diagnostics: Focus auf KI und XR Focus auf KI und XR. Psychologie in Österreich, (4 & 5), 278-285.

--- a/_publications/2025-01-01-OJ6.md
+++ b/_publications/2025-01-01-OJ6.md
@@ -7,9 +7,9 @@ permalink: /publication/2025-01-01-OJ6
 excerpt: 'This article explores the use of artificial intelligence (AI) and extended reality (XR) in clinical-psychological diagnostics. It discusses both the opportunities and challenges of integrating these innovative technologies into diagnostic practice, with a focus on improving assessment accuracy and patient experience. The paper emphasizes the importance of interdisciplinary research to ensure effective and ethically responsible applications.'
 date: 2025-01-01
 venue: 'Published in <i>Psychologie in Österreich</i>, 2025'
-citation: 'Kuhlencord, M., Ohse, J., Fox, J., Peperkorn, N., Rätsch, M., Voigt-Antons, J.-N. &amp; Shiban, Y. (2025). Using promising technologies in clinical-psychological diagnostics: Focus auf KI und XR Focus auf KI und XR. Psychologie in Österreich, (4 &amp; 5), 278-285.'
+citation: 'Kuhlencord, M., Ohse, J., Fox, J., Peperkorn, N., Rätsch, M., Voigt-Antons, J.-N. &amp; Shiban, Y. (2025). Using promising technologies in clinical-psychological diagnostics: Focus auf KI und XR. Psychologie in Österreich, (4 &amp; 5), 278-285.'
 ---
 
 This article explores the use of artificial intelligence (AI) and extended reality (XR) in clinical-psychological diagnostics. It discusses both the opportunities and challenges of integrating these innovative technologies into diagnostic practice, with a focus on improving assessment accuracy and patient experience. The paper emphasizes the importance of interdisciplinary research to ensure effective and ethically responsible applications.
 
-Recommended citation: Kuhlencord, M., Ohse, J., Fox, J., Peperkorn, N., Rätsch, M., Voigt-Antons, J.-N. & Shiban, Y. (2025). Using promising technologies in clinical-psychological diagnostics: Focus auf KI und XR Focus auf KI und XR. Psychologie in Österreich, (4 & 5), 278-285.
+Recommended citation: Kuhlencord, M., Ohse, J., Fox, J., Peperkorn, N., Rätsch, M., Voigt-Antons, J.-N. & Shiban, Y. (2025). Using promising technologies in clinical-psychological diagnostics: Focus auf KI und XR. Psychologie in Österreich, (4 & 5), 278-285.

--- a/_publications/2025-01-01-OJ6.md
+++ b/_publications/2025-01-01-OJ6.md
@@ -7,11 +7,8 @@ permalink: /publication/2025-01-01-OJ6
 excerpt: 'This article explores the use of artificial intelligence (AI) and extended reality (XR) in clinical-psychological diagnostics. It discusses both the opportunities and challenges of integrating these innovative technologies into diagnostic practice, with a focus on improving assessment accuracy and patient experience. The paper emphasizes the importance of interdisciplinary research to ensure effective and ethically responsible applications.'
 date: 2025-01-01
 venue: 'Published in <i>Psychologie in Österreich</i>, 2025'
-paperurl: 'http://dx.doi.org/10.2196/30621'
 citation: 'Kuhlencord, M., Ohse, J., Fox, J., Peperkorn, N., Rätsch, M., Voigt-Antons, J.-N. &amp; Shiban, Y. (2025). Using promising technologies in clinical-psychological diagnostics: Focus auf KI und XR Focus auf KI und XR. Psychologie in Österreich, (4 &amp; 5), 278-285.'
 ---
-
-<a href='http://dx.doi.org/10.2196/30621'>Download publication here.</a>
 
 This article explores the use of artificial intelligence (AI) and extended reality (XR) in clinical-psychological diagnostics. It discusses both the opportunities and challenges of integrating these innovative technologies into diagnostic practice, with a focus on improving assessment accuracy and patient experience. The paper emphasizes the importance of interdisciplinary research to ensure effective and ethically responsible applications.
 

--- a/_publications/2025-06-01-OC44.md
+++ b/_publications/2025-06-01-OC44.md
@@ -1,0 +1,18 @@
+---
+title: "Avatar Appearance Beyond Pixels - User Ratings and Avatar Preferences within Health Applications"
+authors: "Ashrafi, N., Graf, P., Marquardt, M., Vona, F., Schorlemmer, J. & Voigt-Antons, J.-N."
+collection: publications
+category: "conferences"
+permalink: /publication/2025-06-01-OC44
+excerpt: 'We investigate how visual attributes of avatars—such as realism, stylization, gender presentation, and attire—shape user preferences and perceived trust in health-related interactions. In a rating study with diverse participants, we compare multiple avatar designs for telehealth triage, coaching, and data collection scenarios. Results highlight design trade-offs between relatability, professionalism, and privacy, and provide guidelines for selecting avatar styles that foster comfort and adherence.'
+date: 2025-06-01
+venue: 'Paper presented at the International Conference on Human-Computer Interaction (HCII 2025), Gothenburg, Sweden, June 2025'
+paperurl: 'https://doi.org/10.1007/978-3-031-93508-4_11'
+citation: 'Ashrafi, N., Graf, P., Marquardt, M., Vona, F., Schorlemmer, J. &amp; Voigt-Antons, J.-N. (2025, June). Avatar Appearance Beyond Pixels - User Ratings and Avatar Preferences within Health Applications. Paper presented at the International Conference on Human-Computer Interaction (HCII 2025). Gothenburg, Sweden.'
+---
+
+<a href='https://doi.org/10.1007/978-3-031-93508-4_11'>Download publication here.</a>
+
+We investigate how visual attributes of avatars—such as realism, stylization, gender presentation, and attire—shape user preferences and perceived trust in health-related interactions. In a rating study with diverse participants, we compare multiple avatar designs for telehealth triage, coaching, and data collection scenarios. Results highlight design trade-offs between relatability, professionalism, and privacy, and provide guidelines for selecting avatar styles that foster comfort and adherence.
+
+Recommended citation: Ashrafi, N., Graf, P., Marquardt, M., Vona, F., Schorlemmer, J. & Voigt-Antons, J.-N. (2025, June). Avatar Appearance Beyond Pixels - User Ratings and Avatar Preferences within Health Applications. Paper presented at the International Conference on Human-Computer Interaction (HCII 2025). Gothenburg, Sweden.

--- a/_publications/2025-06-01-OC45.md
+++ b/_publications/2025-06-01-OC45.md
@@ -1,0 +1,18 @@
+---
+title: "Exploring the Effects of Different Asymmetric Game Designs on User Experience in Collaborative Virtual Reality"
+authors: "Vona, F., Romanyuk, E., Hinzmann, S., Schorlemmer, J., Ashrafi, N. & Voigt-Antons, J.-N."
+collection: publications
+category: "conferences"
+permalink: /publication/2025-06-01-OC45
+excerpt: 'This paper studies asymmetric collaboration patterns in VR—e.g., complementary abilities, information asymmetry, and device heterogeneity—and their impact on presence, workload, fairness, and enjoyment. Through controlled playtests, we identify design levers that balance challenge and coordination demands while minimizing frustration. The results yield actionable recommendations for crafting satisfying asymmetric co-op experiences.'
+date: 2025-06-01
+venue: 'Paper presented at the International Conference on Human-Computer Interaction (HCII 2025), Gothenburg, Sweden, June 2025'
+paperurl: 'https://doi.org/10.1007/978-3-031-93835-1_24'
+citation: 'Vona, F., Romanyuk, E., Hinzmann, S., Schorlemmer, J., Ashrafi, N. &amp; Voigt-Antons, J.-N. (2025, June). Exploring the Effects of Different Asymmetric Game Designs on User Experience in Collaborative Virtual Reality. Paper presented at the International Conference on Human-Computer Interaction (HCII 2025). Gothenburg, Sweden.'
+---
+
+<a href='https://doi.org/10.1007/978-3-031-93835-1_24'>Download publication here.</a>
+
+This paper studies asymmetric collaboration patterns in VR—e.g., complementary abilities, information asymmetry, and device heterogeneity—and their impact on presence, workload, fairness, and enjoyment. Through controlled playtests, we identify design levers that balance challenge and coordination demands while minimizing frustration. The results yield actionable recommendations for crafting satisfying asymmetric co-op experiences.
+
+Recommended citation: Vona, F., Romanyuk, E., Hinzmann, S., Schorlemmer, J., Ashrafi, N. & Voigt-Antons, J.-N. (2025, June). Exploring the Effects of Different Asymmetric Game Designs on User Experience in Collaborative Virtual Reality. Paper presented at the International Conference on Human-Computer Interaction (HCII 2025). Gothenburg, Sweden.

--- a/_publications/2025-06-01-OC46.md
+++ b/_publications/2025-06-01-OC46.md
@@ -1,0 +1,18 @@
+---
+title: "Sales Skill Training in Virtual Reality: An evaluation utilizing CAVE and Virtual Avatars"
+authors: "Vona, F., Stern, M., Ashrafi, N., Schorlemmer, J., Stemann, J. & Voigt-Antons, J.-N."
+collection: publications
+category: "conferences"
+permalink: /publication/2025-06-01-OC46
+excerpt: 'We evaluate a VR training program for sales conversations using a CAVE setup and avatar-mediated role-play. Compared to baseline materials, trainees show improved confidence, conversational structure, and handling of objections, with strong perceived presence and feedback usefulness. We discuss cost–benefit considerations and guidance for deploying VR sales training at scale.'
+date: 2025-06-01
+venue: 'Paper presented at the International Conference on Human-Computer Interaction (HCII 2025), Gothenburg, Sweden, June 2025'
+paperurl: 'https://doi.org/10.1007/978-3-031-93715-6_16'
+citation: 'Vona, F., Stern, M., Ashrafi, N., Schorlemmer, J., Stemann, J. &amp; Voigt-Antons, J.-N. (2025, June). Sales Skill Training in Virtual Reality: An evaluation utilizing CAVE and Virtual Avatars. Paper presented at the International Conference on Human-Computer Interaction (HCII 2025). Gothenburg, Sweden.'
+---
+
+<a href='https://doi.org/10.1007/978-3-031-93715-6_16'>Download publication here.</a>
+
+We evaluate a VR training program for sales conversations using a CAVE setup and avatar-mediated role-play. Compared to baseline materials, trainees show improved confidence, conversational structure, and handling of objections, with strong perceived presence and feedback usefulness. We discuss cost–benefit considerations and guidance for deploying VR sales training at scale.
+
+Recommended citation: Vona, F., Stern, M., Ashrafi, N., Schorlemmer, J., Stemann, J. & Voigt-Antons, J.-N. (2025, June). Sales Skill Training in Virtual Reality: An evaluation utilizing CAVE and Virtual Avatars. Paper presented at the International Conference on Human-Computer Interaction (HCII 2025). Gothenburg, Sweden.

--- a/_publications/2025-06-01-OC47.md
+++ b/_publications/2025-06-01-OC47.md
@@ -1,0 +1,15 @@
+---
+title: "Enabling Sustainable Everyday Mobility: The Role of E-Cargo Bikes in Urban and Rural Contexts"
+authors: "Voigt-Antons, J.-N, Ceranic, M. & Vona, F."
+collection: publications
+category: "conferences"
+permalink: /publication/2025-06-01-OC47
+excerpt: 'This poster explores how e-cargo bikes can support sustainable daily mobility for families and small businesses across urban and rural settings. We synthesize findings from user interviews, ride-alongs, and route logging to identify adoption barriers (infrastructure, storage, weather, safety) and enabling service concepts. Design implications target routing, cargo management, and shared-use schemes.'
+date: 2025-06-01
+venue: 'Poster presented at the International Conference on Human-Computer Interaction (HCII 2025), Gothenburg, Sweden, June 2025'
+citation: 'Voigt-Antons, J.-N, Ceranic, M. &amp; Vona, F. (2025, June). Enabling Sustainable Everyday Mobility: The Role of E-Cargo Bikes in Urban and Rural Contexts. Poster presented at the International Conference on Human-Computer Interaction (HCII 2025). Gothenburg, Sweden.'
+---
+
+This poster explores how e-cargo bikes can support sustainable daily mobility for families and small businesses across urban and rural settings. We synthesize findings from user interviews, ride-alongs, and route logging to identify adoption barriers (infrastructure, storage, weather, safety) and enabling service concepts. Design implications target routing, cargo management, and shared-use schemes.
+
+Recommended citation: Voigt-Antons, J.-N, Ceranic, M. & Vona, F. (2025, June). Enabling Sustainable Everyday Mobility: The Role of E-Cargo Bikes in Urban and Rural Contexts. Poster presented at the International Conference on Human-Computer Interaction (HCII 2025). Gothenburg, Sweden.

--- a/_publications/2025-06-01-OC48.md
+++ b/_publications/2025-06-01-OC48.md
@@ -1,0 +1,18 @@
+---
+title: "Optimized User Experience for Labeling Systems for Predictive Maintenance Applications"
+authors: "Hallmann, M., Stern, M., Franke, U., Ostertag, T., da Costa, J. P. & Voigt-Antons, J.-N."
+collection: publications
+category: "conferences"
+permalink: /publication/2025-06-01-OC48
+excerpt: 'We present a UX-driven redesign of industrial labeling tools for predictive maintenance datasets. Through contextual inquiry with domain experts, we identify pain points in annotation flow, error recovery, and metadata capture, and evaluate prototypes that reduce time-on-task and labeling errors. Results inform design patterns for scalable, operator-friendly annotation in industrial contexts.'
+date: 2025-06-01
+venue: 'Paper presented at the International Conference on Human-Computer Interaction (HCII 2025), Gothenburg, Sweden, June 2025'
+paperurl: 'https://doi.org/10.1007/978-3-031-92689-1_13'
+citation: 'Hallmann, M., Stern, M., Franke, U., Ostertag, T., da Costa, J. P. &amp; Voigt-Antons, J.-N. (2025, June). Optimized User Experience for Labeling Systems for Predictive Maintenance Applications. Paper presented at the International Conference on Human-Computer Interaction (HCII 2025). Gothenburg, Sweden.'
+---
+
+<a href='https://doi.org/10.1007/978-3-031-92689-1_13'>Download publication here.</a>
+
+We present a UX-driven redesign of industrial labeling tools for predictive maintenance datasets. Through contextual inquiry with domain experts, we identify pain points in annotation flow, error recovery, and metadata capture, and evaluate prototypes that reduce time-on-task and labeling errors. Results inform design patterns for scalable, operator-friendly annotation in industrial contexts.
+
+Recommended citation: Hallmann, M., Stern, M., Franke, U., Ostertag, T., da Costa, J. P. & Voigt-Antons, J.-N. (2025, June). Optimized User Experience for Labeling Systems for Predictive Maintenance Applications. Paper presented at the International Conference on Human-Computer Interaction (HCII 2025). Gothenburg, Sweden.

--- a/_publications/2025-06-01-OC49.md
+++ b/_publications/2025-06-01-OC49.md
@@ -1,0 +1,18 @@
+---
+title: "Comparing User Behavior in Real vs. Virtual Supermarket Shelves: An Eye-Tracking Study Using Tobii 3 Pro and Meta Quest Pro"
+authors: "Vona, F., Kaulard, P., Schorlemmer, J., Stemann, J., Fischer, S. & Voigt-Antons, J.-N."
+collection: publications
+category: "conferences"
+permalink: /publication/2025-06-01-OC49
+excerpt: 'We compare gaze behavior and product selection strategies between physical supermarket shelves and their VR twins. Using head-mounted and desktop eye tracking (Tobii Pro 3) and integrated VR eye tracking (Meta Quest Pro), we analyze fixation patterns, dwell time, and choice latency. Results discuss ecological validity of VR shopping studies and conditions under which VR approximates in-store behavior.'
+date: 2025-06-01
+venue: 'Poster presented at the International Conference on Human-Computer Interaction (HCII 2025), Gothenburg, Sweden, June 2025'
+paperurl: 'https://doi.org/10.1007/978-3-031-94168-9_39'
+citation: 'Vona, F., Kaulard, P., Schorlemmer, J., Stemann, J., Fischer, S. &amp; Voigt-Antons, J.-N. (2025, June). Comparing User Behavior in Real vs. Virtual Supermarket Shelves: An Eye-Tracking Study Using Tobii 3 Pro and Meta Quest Pro. Poster presented at the International Conference on Human-Computer Interaction (HCII 2025). Gothenburg, Sweden.'
+---
+
+<a href='https://doi.org/10.1007/978-3-031-94168-9_39'>Download publication here.</a>
+
+We compare gaze behavior and product selection strategies between physical supermarket shelves and their VR twins. Using head-mounted and desktop eye tracking (Tobii Pro 3) and integrated VR eye tracking (Meta Quest Pro), we analyze fixation patterns, dwell time, and choice latency. Results discuss ecological validity of VR shopping studies and conditions under which VR approximates in-store behavior.
+
+Recommended citation: Vona, F., Kaulard, P., Schorlemmer, J., Stemann, J., Fischer, S. & Voigt-Antons, J.-N. (2025, June). Comparing User Behavior in Real vs. Virtual Supermarket Shelves: An Eye-Tracking Study Using Tobii 3 Pro and Meta Quest Pro. Poster presented at the International Conference on Human-Computer Interaction (HCII 2025). Gothenburg, Sweden.

--- a/_publications/2025-06-01-OC50.md
+++ b/_publications/2025-06-01-OC50.md
@@ -1,0 +1,18 @@
+---
+title: "Integrating Virtual and Augmented Reality into Public Education: Opportunities and Challenges in Language Learning"
+authors: "Kojić, T., Vergari, M., Benta, G.-M., Krupinski, J., Warsinke, M., Möller, S. & Voigt-Antons, J.-N."
+collection: publications
+category: "conferences"
+permalink: /publication/2025-06-01-OC50
+excerpt: 'We present a framework for adopting VR/AR in public-sector language education, synthesizing evidence from pilot deployments and teacher workshops. The paper outlines benefits for immersion, motivation, and situated practice, alongside barriers such as device logistics, accessibility, assessment alignment, and teacher training. Practical guidelines are provided for curriculum integration and sustainable scaling.'
+date: 2025-06-01
+venue: 'Paper presented at the International Conference on Human-Computer Interaction (HCII 2025), Gothenburg, Sweden, June 2025'
+paperurl: 'https://doi.org/10.1007/978-3-031-93715-6_9'
+citation: 'Kojić, T., Vergari, M., Benta, G.-M., Krupinski, J., Warsinke, M., Möller, S. &amp; Voigt-Antons, J.-N. (2025, June). Integrating Virtual and Augmented Reality into Public Education: Opportunities and Challenges in Language Learning. Paper presented at the International Conference on Human-Computer Interaction (HCII 2025). Gothenburg, Sweden.'
+---
+
+<a href='https://doi.org/10.1007/978-3-031-93715-6_9'>Download publication here.</a>
+
+We present a framework for adopting VR/AR in public-sector language education, synthesizing evidence from pilot deployments and teacher workshops. The paper outlines benefits for immersion, motivation, and situated practice, alongside barriers such as device logistics, accessibility, assessment alignment, and teacher training. Practical guidelines are provided for curriculum integration and sustainable scaling.
+
+Recommended citation: Kojić, T., Vergari, M., Benta, G.-M., Krupinski, J., Warsinke, M., Möller, S. & Voigt-Antons, J.-N. (2025, June). Integrating Virtual and Augmented Reality into Public Education: Opportunities and Challenges in Language Learning. Paper presented at the International Conference on Human-Computer Interaction (HCII 2025). Gothenburg, Sweden.

--- a/_publications/2025-08-01-OC53.md
+++ b/_publications/2025-08-01-OC53.md
@@ -1,0 +1,18 @@
+---
+title: "Too Immersive for the Field? Addressing Safety Risks in Extended Reality User Studies"
+authors: "Kojic, T., Srebot, S., Vergari, M., Moslavac, M., Warsinke, M., Möller, S., Skorin-Kapov, L., Voigt-Antons, J.-N."
+collection: publications
+category: "conferences"
+permalink: /publication/2025-08-01-OC53
+excerpt: 'This work surveys safety risks that arise when conducting XR user studies beyond the lab, including reduced situational awareness, bystander exposure, and environment-induced hazards. We propose a practical risk taxonomy and mitigation toolkit—covering protocol design, wearable safety, geofencing, supervision, and debriefing—and illustrate its use with pilot field deployments. The paper aims to support ethics reviews and standardize reporting of safety measures in XR research.'
+date: 2025-08-01
+venue: 'Paper presented at the Mensch und Computer 2025 (MuC 2025), Chemnitz, Germany, August 2025'
+paperurl: 'https://doi.org/10.18420/muc2025-mci-ws13-231'
+citation: 'Kojic, T., Srebot, S., Vergari, M., Moslavac, M., Warsinke, M., Möller, S., Skorin-Kapov, L., Voigt-Antons, J.-N. (2025, August). Too Immersive for the Field? Addressing Safety Risks in Extended Reality User Studies. Paper presented at the Mensch und Computer 2025 (MuC 2025). Chemnitz, Germany.'
+---
+
+<a href='https://doi.org/10.18420/muc2025-mci-ws13-231'>Download publication here.</a>
+
+This work surveys safety risks that arise when conducting XR user studies beyond the lab, including reduced situational awareness, bystander exposure, and environment-induced hazards. We propose a practical risk taxonomy and mitigation toolkit—covering protocol design, wearable safety, geofencing, supervision, and debriefing—and illustrate its use with pilot field deployments. The paper aims to support ethics reviews and standardize reporting of safety measures in XR research.
+
+Recommended citation: Kojic, T., Srebot, S., Vergari, M., Moslavac, M., Warsinke, M., Möller, S., Skorin-Kapov, L., Voigt-Antons, J.-N. (2025, August). Too Immersive for the Field? Addressing Safety Risks in Extended Reality User Studies. Paper presented at the Mensch und Computer 2025 (MuC 2025). Chemnitz, Germany.

--- a/_publications/2025-09-01-OC51.md
+++ b/_publications/2025-09-01-OC51.md
@@ -1,0 +1,15 @@
+---
+title: "Nutzererfahrung von Kindern und Jugendlichen mit einem multimodalen, interaktiven System zur digitalen Erfassung von patient-reported outcomes"
+authors: "Marquardt, M., Ashrafi, N., Compagna, D., Giolo, S., Graf, P., Harnisch, P., Hillmann, S., Voigt-Antons, J.-N. & Balcerek, M."
+collection: publications
+category: "conferences"
+permalink: /publication/2025-09-01-OC51
+excerpt: 'This poster reports on the usability and acceptance of a multimodal, interactive system for digitally capturing patient-reported outcomes among children and adolescents. Through iterative testing in pediatric contexts, we evaluate age-appropriate interaction (voice, touch, avatar guidance), comprehension, engagement, and burden. Insights translate into design recommendations for inclusive PROM workflows in child and adolescent medicine.'
+date: 2025-09-01
+venue: 'Poster presented at the Kongresses für Kinder- und Jugendmedizin (KKJ 2025), Leipzig, Germany, September 2025'
+citation: 'Marquardt, M., Ashrafi, N., Compagna, D., Giolo, S., Graf, P., Harnisch, P., Hillmann, S., Voigt-Antons, J.-N. &amp; Balcerek, M. (2025, September). Nutzererfahrung von Kindern und Jugendlichen mit einem multimodalen, interaktiven System zur digitalen Erfassung von patient-reported outcomes. Poster presented at the Kongresses für Kinder- und Jugendmedizin (KKJ 2025). Leipzig, Germany.'
+---
+
+This poster reports on the usability and acceptance of a multimodal, interactive system for digitally capturing patient-reported outcomes among children and adolescents. Through iterative testing in pediatric contexts, we evaluate age-appropriate interaction (voice, touch, avatar guidance), comprehension, engagement, and burden. Insights translate into design recommendations for inclusive PROM workflows in child and adolescent medicine.
+
+Recommended citation: Marquardt, M., Ashrafi, N., Compagna, D., Giolo, S., Graf, P., Harnisch, P., Hillmann, S., Voigt-Antons, J.-N. & Balcerek, M. (2025, September). Nutzererfahrung von Kindern und Jugendlichen mit einem multimodalen, interaktiven System zur digitalen Erfassung von patient-reported outcomes. Poster presented at the Kongresses für Kinder- und Jugendmedizin (KKJ 2025). Leipzig, Germany.

--- a/_publications/2025-10-01-OC52.md
+++ b/_publications/2025-10-01-OC52.md
@@ -1,0 +1,15 @@
+---
+title: "Comparing robot, avatar, and voice assistance in PROMIS administration – a cross-randomized controlled trial"
+authors: "Marquardt, M., Ashrafi, N., Balcerek, M., Compagna, D., Graf, P., Harnisch, P., Hillmann, S., Köllner, V., Papst, L., Voigt-Antons, J.-N., Zöllick, J. & Fischer, Felix"
+collection: publications
+category: "conferences"
+permalink: /publication/2025-10-01-OC52
+excerpt: 'We compare three assistance modalities—social robot, embodied avatar, and disembodied voice—for administering PROMIS questionnaires in clinical settings. Outcomes include completion time, missing data, user trust, workload, and perceived empathy across diverse patient groups. Findings highlight trade-offs between efficiency and engagement and inform the selection of assistance for equitable, high-quality PROM capture.'
+date: 2025-10-01
+venue: 'Paper presented at the 11th Annual PROMIS International Conference (PROMIS 2025), Milwaukee, Wisconsin, USA, October 2025'
+citation: 'Marquardt, M., Ashrafi, N., Balcerek, M., Compagna, D., Graf, P., Harnisch, P., Hillmann, S., Köllner, V., Papst, L., Voigt-Antons, J.-N., Zöllick, J. &amp; Fischer, Felix (2025, October). Comparing robot, avatar, and voice assistance in PROMIS administration – a cross-randomized controlled trial. Paper presented at the 11th Annual PROMIS International Conference (PROMIS 2025). Milwaukee, Wisconsin USA.'
+---
+
+We compare three assistance modalities—social robot, embodied avatar, and disembodied voice—for administering PROMIS questionnaires in clinical settings. Outcomes include completion time, missing data, user trust, workload, and perceived empathy across diverse patient groups. Findings highlight trade-offs between efficiency and engagement and inform the selection of assistance for equitable, high-quality PROM capture.
+
+Recommended citation: Marquardt, M., Ashrafi, N., Balcerek, M., Compagna, D., Graf, P., Harnisch, P., Hillmann, S., Köllner, V., Papst, L., Voigt-Antons, J.-N., Zöllick, J. & Fischer, Felix (2025, October). Comparing robot, avatar, and voice assistance in PROMIS administration – a cross-randomized controlled trial. Paper presented at the 11th Annual PROMIS International Conference (PROMIS 2025). Milwaukee, Wisconsin USA.

--- a/_publications/2026-03-01-OC54.md
+++ b/_publications/2026-03-01-OC54.md
@@ -1,0 +1,15 @@
+---
+title: "A Modular Multimodal Dialog Architecture for Digital PROM Collection"
+authors: "Hillmann, S., Harnisch, P., Schuhmann, D., Ashrafi, N. & Voigt-Antons, J.-N."
+collection: publications
+category: "conferences"
+permalink: /publication/2026-03-01-OC54
+excerpt: 'This paper presents a modular multimodal dialog architecture designed to support the digital collection of Patient-Reported Outcome Measures (PROMs). The architecture integrates speech, touch, and visual interaction components and emphasizes extensibility, robustness, and adaptability to different user groups and clinical contexts. The work discusses design requirements, system components, and interaction flow, aiming to facilitate reliable and user-centered PROM acquisition in healthcare applications.'
+date: 2026-03-01
+venue: 'Paper presented at the Conference on Electronic Speech Signal Processing 2026 (ESSV 2026), Eichstätt, Germany, March 2026'
+citation: 'Hillmann, S., Harnisch, P., Schuhmann, D., Ashrafi, N. &amp; Voigt-Antons, J.-N. (2026, March). A Modular Multimodal Dialog Architecture for Digital PROM Collection. Paper presented at the Conference on Electronic Speech Signal Processing 2026 (ESSV 2026). Eichstätt, Germany.'
+---
+
+This paper presents a modular multimodal dialog architecture designed to support the digital collection of Patient-Reported Outcome Measures (PROMs). The architecture integrates speech, touch, and visual interaction components and emphasizes extensibility, robustness, and adaptability to different user groups and clinical contexts. The work discusses design requirements, system components, and interaction flow, aiming to facilitate reliable and user-centered PROM acquisition in healthcare applications.
+
+Recommended citation: Hillmann, S., Harnisch, P., Schuhmann, D., Ashrafi, N. & Voigt-Antons, J.-N. (2026, March). A Modular Multimodal Dialog Architecture for Digital PROM Collection. Paper presented at the Conference on Electronic Speech Signal Processing 2026 (ESSV 2026). Eichstätt, Germany.


### PR DESCRIPTION
### Motivation
- Bring the website's publications up to date by adding the missing entries from the provided publication list (new journal and conference items). 
- Preserve the full abstracts/excerpts exactly as provided (no shortening) so each publication page shows the complete description.

### Description
- Added 14 new markdown publication pages under `_publications` for the IDs `OJ6` and `OC42`–`OC54`, each with YAML front matter including `title`, `authors`, `collection`, `category`, `permalink`, `excerpt`, `date`, `venue`, optional `paperurl` where provided, and `citation`.
- Each file body includes a download link when a paper URL was supplied, the full abstract/excerpt (unshortened), and a `Recommended citation` line mirroring the provided citation string.
- Filenames follow the repository convention `YYYY-MM-DD-<ID>.md` (e.g. `_publications/2025-01-01-OJ6.md`).

### Testing
- Ran a front-matter sanity check using a short Python script that verified each new file starts with `---` and contains a closing front matter delimiter `\n---\n`, and the check passed. 
- Created the new publication files via a targeted Python script that wrote the expected YAML and content, and verified the top lines of each created file with `nl` to confirm metadata and excerpts were present. 
- Attempted a site build with `bundle exec jekyll build`, which failed in this environment because the `jekyll` executable is not installed (`bundler: command not found: jekyll`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992412f84c08330b57db854920296e0)