### PR TITLE
Update About page with expanded professional profile text

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -7,8 +7,7 @@ redirect_from:
   - /about.html
 ---
 
-I am **Prof. Dr.-Ing. Jan-Niklas Voigt-Antons**, leading research in human-centered immersive technologies at the **Immersive Reality Lab**.
-
-My work focuses on how people experience and interact with digital systems across **extended reality (XR)**, **quality of experience (QoE)**, and **physiological and behavioral measurement**. Current projects in our lab cover topics such as socially acceptable XR interfaces, immersive learning and training, AI-supported interaction, and digital health applications.
-
-I collaborate across academia and industry to turn research into practical, inclusive, and evidence-based solutions. If you are interested in collaborating, supervising student projects, or discussing research transfer, feel free to get in touch.
+About
+I am Prof. Dr.-Ing. Jan-Niklas Voigt-Antons, a professor and research group leader in human-centered Extended Reality (XR: VR/AR/MR), Spatial Computing, and Digital Experience (UX/UI). I lead the Immersive Reality Lab, where we design, implement, and rigorously evaluate immersive 3D systems—ranging from real-time simulations and game-engine prototypes to spatial interfaces and interactive 3D worlds—for learning, training, and health- and safety-relevant applications.
+My research sits at the intersection of computer science, interaction design, and human factors/engineering psychology. I study how people perceive, trust, and effectively use interactive systems, combining Quality of Experience (QoE) methods with behavioral and physiological measurement to produce evidence-based design guidance. Current work includes socially acceptable XR interaction, immersive learning and serious games, AI-supported interaction, and human-in-the-loop evaluation in simulator-like environments.
+In teaching, I cover both foundations and advanced practice: technical and mathematical XR basics, computer graphics and real-time rendering, game development with modern engines, and UX for complex spatial interfaces—delivered in project-based formats with strong transfer orientation. I actively collaborate with academia, industry, and public-sector partners, acquire and run third-party funded projects, and supervise student research from early prototypes to publication-ready results. If you are interested in collaboration, research transfer, or supervising theses and student projects, please get in touch.

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -11,6 +11,15 @@ I am Prof. Dr.-Ing. Jan-Niklas Voigt-Antons, a professor and research group lead
 
 Research areas: Extended Reality (XR), Spatial Computing, Spatial Interaction Design, Digital Experience (UX/UI), Quality of Experience (QoE), physiological and behavioral measurement, immersive learning, serious games, digital health.
 
+<nav aria-label="Quick links">
+  <ul>
+    <li><a href="/teaching/">Teaching (XR &amp; Game Development)</a></li>
+    <li><a href="/research/">Research (QoE &amp; Physiological Measurement)</a></li>
+    <li><a href="/projects/">Projects &amp; Transfer</a></li>
+    <li><a href="/publications/">Publications</a></li>
+  </ul>
+</nav>
+
 My research sits at the intersection of computer science, interaction design, and human factors/engineering psychology. I study how people perceive, trust, and effectively use interactive systems, combining Quality of Experience (QoE) methods with behavioral and physiological measurement to produce evidence-based design guidance. Current work includes socially acceptable XR interaction, immersive learning and serious games, AI-supported interaction, and human-in-the-loop evaluation in simulator-like environments.
 
 In teaching, I cover both foundations and advanced practice: technical and mathematical XR basics, computer graphics and real-time rendering, game development with modern engines, and UX for complex spatial interfaces—delivered in project-based formats with strong transfer orientation. I actively collaborate with academia, industry, and public-sector partners, acquire and run third-party funded projects, and supervise student research from early prototypes to publication-ready results. If you are interested in collaboration, research transfer, or supervising theses and student projects, please get in touch.

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -7,7 +7,10 @@ redirect_from:
   - /about.html
 ---
 
-About
 I am Prof. Dr.-Ing. Jan-Niklas Voigt-Antons, a professor and research group leader in human-centered Extended Reality (XR: VR/AR/MR), Spatial Computing, and Digital Experience (UX/UI). I lead the Immersive Reality Lab, where we design, implement, and rigorously evaluate immersive 3D systems—ranging from real-time simulations and game-engine prototypes to spatial interfaces and interactive 3D worlds—for learning, training, and health- and safety-relevant applications.
+
+Research areas: Extended Reality (XR), Spatial Computing, Spatial Interaction Design, Digital Experience (UX/UI), Quality of Experience (QoE), physiological and behavioral measurement, immersive learning, serious games, digital health.
+
 My research sits at the intersection of computer science, interaction design, and human factors/engineering psychology. I study how people perceive, trust, and effectively use interactive systems, combining Quality of Experience (QoE) methods with behavioral and physiological measurement to produce evidence-based design guidance. Current work includes socially acceptable XR interaction, immersive learning and serious games, AI-supported interaction, and human-in-the-loop evaluation in simulator-like environments.
+
 In teaching, I cover both foundations and advanced practice: technical and mathematical XR basics, computer graphics and real-time rendering, game development with modern engines, and UX for complex spatial interfaces—delivered in project-based formats with strong transfer orientation. I actively collaborate with academia, industry, and public-sector partners, acquire and run third-party funded projects, and supervise student research from early prototypes to publication-ready results. If you are interested in collaboration, research transfer, or supervising theses and student projects, please get in touch.


### PR DESCRIPTION
### Motivation
- Replace the concise About blurb with the full, expanded professional biography provided for Prof. Dr.-Ing. Jan-Niklas Voigt-Antons.  
- Keep site routing and author-profile metadata intact so the page continues to publish at the same permalink and redirects.

### Description
- Replaced the content body in `_pages/about.md` with the new multi-paragraph biography while preserving the existing YAML front matter.  
- The change only touches the About page content and does not alter any site configuration or other pages.  
- No structural or format changes were made to front matter or page routing (`permalink`, `redirect_from`, `author_profile`).

### Testing
- Located and inspected occurrences with `rg` to confirm the target file was updated.  
- Opened and reviewed the updated file contents with `sed -n` / `nl` to verify the new biography text is present in `_pages/about.md`.  
- Attempted to run a local preview with `bundle install` and `bundle exec jekyll serve` for visual verification, but `bundle install` failed due to `rubygems.org` returning HTTP 403 in this environment so a full site preview could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69924aa0b52483309d47f80515d197a6)