### PR TITLE
Add quick-links navigation block to homepage About section

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -7,8 +7,19 @@ redirect_from:
   - /about.html
 ---
 
-I am **Prof. Dr.-Ing. Jan-Niklas Voigt-Antons**, leading research in human-centered immersive technologies at the **Immersive Reality Lab**.
+I am Prof. Dr.-Ing. Jan-Niklas Voigt-Antons, a professor and research group leader in human-centered Extended Reality (XR: VR/AR/MR), Spatial Computing, and Digital Experience (UX/UI). I lead the Immersive Reality Lab, where we design, implement, and rigorously evaluate immersive 3D systems—ranging from real-time simulations and game-engine prototypes to spatial interfaces and interactive 3D worlds—for learning, training, and health- and safety-relevant applications.
 
-My work focuses on how people experience and interact with digital systems across **extended reality (XR)**, **quality of experience (QoE)**, and **physiological and behavioral measurement**. Current projects in our lab cover topics such as socially acceptable XR interfaces, immersive learning and training, AI-supported interaction, and digital health applications.
+Research areas: Extended Reality (XR), Spatial Computing, Spatial Interaction Design, Digital Experience (UX/UI), Quality of Experience (QoE), physiological and behavioral measurement, immersive learning, serious games, digital health.
 
-I collaborate across academia and industry to turn research into practical, inclusive, and evidence-based solutions. If you are interested in collaborating, supervising student projects, or discussing research transfer, feel free to get in touch.
+<nav aria-label="Quick links">
+  <ul>
+    <li><a href="/teaching/">Teaching (XR &amp; Game Development)</a></li>
+    <li><a href="/research/">Research (QoE &amp; Physiological Measurement)</a></li>
+    <li><a href="/projects/">Projects &amp; Transfer</a></li>
+    <li><a href="/publications/">Publications</a></li>
+  </ul>
+</nav>
+
+My research sits at the intersection of computer science, interaction design, and human factors/engineering psychology. I study how people perceive, trust, and effectively use interactive systems, combining Quality of Experience (QoE) methods with behavioral and physiological measurement to produce evidence-based design guidance. Current work includes socially acceptable XR interaction, immersive learning and serious games, AI-supported interaction, and human-in-the-loop evaluation in simulator-like environments.
+
+In teaching, I cover both foundations and advanced practice: technical and mathematical XR basics, computer graphics and real-time rendering, game development with modern engines, and UX for complex spatial interfaces—delivered in project-based formats with strong transfer orientation. I actively collaborate with academia, industry, and public-sector partners, acquire and run third-party funded projects, and supervise student research from early prototypes to publication-ready results. If you are interested in collaboration, research transfer, or supervising theses and student projects, please get in touch.


### PR DESCRIPTION
### Motivation
- Improve homepage navigation by surfacing core site areas (Teaching, Research, Projects, Publications) directly on the About/home page. 
- Keep the expanded biography and existing routing/front-matter intact while adding a compact, accessible link block.

### Description
- Inserted a semantic `nav` block with `aria-label="Quick links"` and an unordered list of links to `/teaching/`, `/research/`, `/projects/`, and `/publications/` directly beneath the existing “Research areas” line in `_pages/about.md`.
- Preserved the YAML front matter (`permalink`, `title`, `author_profile`, `redirect_from`) and the rest of the About copy without other layout changes.
- Committed the change with the message `Add homepage quick links block to About page`.

### Testing
- Verified the file update with `git diff -- _pages/about.md` and inspected the file using `sed -n` which showed the new `nav` block in place (success).
- Attempted `bundle install` to run a local Jekyll preview but it failed due to `rubygems.org` returning HTTP 403 in this environment (failure).
- Attempted an automated Playwright screenshot of `http://127.0.0.1:4000` but it failed with `ERR_EMPTY_RESPONSE` because the local Jekyll server could not be started (failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69924aa0b52483309d47f80515d197a6)