### PR TITLE
Fix rendering of Selected publications block on publications page

### DIFF
--- a/_pages/publications.html
+++ b/_pages/publications.html
@@ -8,25 +8,33 @@ description: "Selected and complete publications with filtering by year, type, v
 
 <div class="wordwrap"><strong>External profiles:</strong> <a href="https://scholar.google.com/citations?user=IFIaOZsAAAAJ">Google Scholar</a> · <a href="https://dblp.org/pid/39/10762">DBLP</a> · <a href="https://dl.acm.org/profile/99659317387">ACM DL</a> · <a href="https://orcid.org/0000-0002-2786-9262">ORCID</a></div>
 
-## Selected publications
+<h2>Selected publications</h2>
 
-### XR & Spatial Interaction
-- [Perceptibility and Preference of Dynamic Weight Changes in Virtual Reality Through Pseudo-Haptic and Vibrotactile Cues](/publication/2024-12-01-C83)
-- [Towards Socially Acceptable Virtual Reality Interactions in Public Contexts](/publication/2025-06-01-C89)
+<h3>XR &amp; Spatial Interaction</h3>
+<ul>
+  <li><a href="/publication/2024-12-01-C83">Perceptibility and Preference of Dynamic Weight Changes in Virtual Reality Through Pseudo-Haptic and Vibrotactile Cues</a></li>
+  <li><a href="/publication/2025-06-01-C89">Towards Socially Acceptable Virtual Reality Interactions in Public Contexts</a></li>
+</ul>
 
-### Quality of Experience (QoE)
-- [A quality of experience approach for cloud gaming in virtual reality](/publication/2024-07-01-J29)
-- [Dynamic and Responsible Digital Twins for Extended Reality](/publication/2025-09-01-J32)
+<h3>Quality of Experience (QoE)</h3>
+<ul>
+  <li><a href="/publication/2024-07-01-J29">A quality of experience approach for cloud gaming in virtual reality</a></li>
+  <li><a href="/publication/2025-09-01-J32">Dynamic and Responsible Digital Twins for Extended Reality</a></li>
+</ul>
 
-### Psychophysiology & Behavioral Measurement
-- [Arousal Effects on Evaluation and Perception in Multimedia Quality](/publication/2023-03-02-J25)
-- [User-centered measurements for immersive interaction quality](/publication/2025-01-01-C84)
+<h3>Psychophysiology &amp; Behavioral Measurement</h3>
+<ul>
+  <li><a href="/publication/2023-03-02-J25">Arousal Effects on Evaluation and Perception in Multimedia Quality</a></li>
+  <li><a href="/publication/2025-01-01-C84">User-centered measurements for immersive interaction quality</a></li>
+</ul>
 
-### Digital Health & Learning
-- [The digitalization of healthcare for older adults (book)](https://berlinup.books.tu-berlin.de/en/autor_innen/jan-niklas-voigt-antons/)
-- [Current and Future Trends in Human-Centered Digitalization in Healthcare (2024 editorship)](/publication/2024-10-16-BC4)
+<h3>Digital Health &amp; Learning</h3>
+<ul>
+  <li><a href="https://berlinup.books.tu-berlin.de/en/autor_innen/jan-niklas-voigt-antons/">The digitalization of healthcare for older adults (book)</a></li>
+  <li><a href="/publication/2024-10-16-BC4">Current and Future Trends in Human-Centered Digitalization in Healthcare (2024 editorship)</a></li>
+</ul>
 
-## Filter all publications
+<h2>Filter all publications</h2>
 
 <label for="pub-filter-year">Year:</label>
 <select id="pub-filter-year"><option value="">All</option></select>


### PR DESCRIPTION
### Motivation
- The `Selected publications` block in `_pages/publications.html` used markdown-style headings and list markers which do not render when embedded in an HTML template, producing malformed output on the page.  
- Converting that fragment to explicit HTML ensures the section renders consistently and remains accessible across page templates.

### Description
- Replace markdown headings and list markers with HTML elements in `_pages/publications.html`, using `<h2>` for the section title, `<h3>` for topic headings, and `<ul>/<li>` for the publication lists.  
- Escape ampersands in headings (`&` -> `&amp;`) and preserve all original publication links and URLs.  
- Convert the "Filter all publications" label into an actual heading (`<h2>`) for consistent semantics and styling.

### Testing
- Attempted `bundle exec jekyll build`, which failed in this environment because the `jekyll` executable is not available (automated build could not run).  
- Served the repository with `python3 -m http.server 8000` and captured a browser screenshot of `/_pages/publications.html` to visually verify the corrected headings and lists, and the screenshot was produced successfully.  
- Confirmed the change is limited to the ` _pages/publications.html` file and that the original publication links and text were preserved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69977465576883309a940a21a95c240e)