### PR TITLE
Suppress teaching metadata lines on teaching archive page

### DIFF
--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -42,7 +42,7 @@
       <p class="page__meta"><i class="fa fa-clock-o" aria-hidden="true"></i> {% include read-time.html %}</p>
     {% endif %}
 
-        {% if post.collection == 'teaching' %}
+        {% if post.collection == 'teaching' and include.hide_teaching_meta != true %}
           <p> {{ post.type }}, <i>{{ post.venue }}</i>, {{ post.date | default: "1900-01-01" | date: "%Y" }} </p>
         {% elsif post.collection == 'publications' %}
           <p> </p>

--- a/_pages/teaching.html
+++ b/_pages/teaching.html
@@ -51,5 +51,5 @@ I teach immersive technologies as a combination of technical implementation, hum
 ## Current teaching entries
 
 {% for post in site.teaching reversed %}
-  {% include archive-single.html %}
+  {% include archive-single.html hide_teaching_meta=true %}
 {% endfor %}


### PR DESCRIPTION
### Motivation
- Make the teaching archive page cleaner by removing the inline `type, venue, year` metadata lines (e.g. “Research seminar, Hamm-Lippstadt University of Applied Sciences, 2024”) from each teaching entry when rendered on the `/teaching/` page.

### Description
- Add a conditional to `_includes/archive-single.html` so the teaching metadata line is rendered only when `include.hide_teaching_meta != true`.
- Update `_pages/teaching.html` to call the include with `hide_teaching_meta=true` so the metadata is suppressed for entries on the teaching archive.
- Changed files: `_includes/archive-single.html` and `_pages/teaching.html`.

### Testing
- Confirmed the template edits were written and validated by inspecting the diffs of the modified files.
- Attempted `bundle exec jekyll build`, which failed because the `jekyll` executable is not available in the environment. 
- Attempted `bundle install`, which failed with `403 Forbidden` when fetching gems from `rubygems.org`, so dependencies could not be installed. 
- Attempted a Playwright page snapshot of `http://127.0.0.1:4000/teaching/`, which failed with `ERR_EMPTY_RESPONSE` because no local site server was available due to the build/dependency issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699775bc501883308ae1c8be8acd8d33)