### PR TITLE
Fix teaching page heading and list formatting

### DIFF
--- a/_pages/teaching.html
+++ b/_pages/teaching.html
@@ -6,11 +6,11 @@ author_profile: true
 description: "Teaching portfolio in Virtual Reality, Augmented Reality, immersive systems design, and research-led project formats."
 ---
 
-## Teaching philosophy
+<h2>Teaching philosophy</h2>
 
-I teach immersive technologies as a combination of technical implementation, human-centered design, and empirical evaluation.
+<p>I teach immersive technologies as a combination of technical implementation, human-centered design, and empirical evaluation.</p>
 
-## Courses taught
+<h2>Courses taught</h2>
 
 <table>
   <thead>
@@ -37,18 +37,22 @@ I teach immersive technologies as a combination of technical implementation, hum
   </tbody>
 </table>
 
-## Teaching formats
+<h2>Teaching formats</h2>
 
-- Project-based learning with iterative prototypes
-- Lab-based experiments in immersive environments
-- Research-linked seminar formats with publication pathways
+<ul>
+  <li>Project-based learning with iterative prototypes</li>
+  <li>Lab-based experiments in immersive environments</li>
+  <li>Research-linked seminar formats with publication pathways</li>
+</ul>
 
-## Supervision
+<h2>Supervision</h2>
 
-- Typical supervision volume: multiple theses and project groups per year across XR, QoE, and digital health topics.
-- Example topics: social acceptability in XR, QoE under network degradation, multimodal user-state assessment, and XR-based training concepts.
+<ul>
+  <li>Typical supervision volume: multiple theses and project groups per year across XR, QoE, and digital health topics.</li>
+  <li>Example topics: social acceptability in XR, QoE under network degradation, multimodal user-state assessment, and XR-based training concepts.</li>
+</ul>
 
-## Current teaching entries
+<h2>Current teaching entries</h2>
 
 {% for post in site.teaching reversed %}
   {% include archive-single.html %}


### PR DESCRIPTION
### Motivation
- The teaching page mixed Markdown `##` headings and Markdown lists inside an HTML/Jekyll page that contains an HTML table, which can produce inconsistent rendering; the change ensures stable HTML rendering for headings and lists.

### Description
- Replace markdown `##` section headings with explicit HTML `<h2>` tags for all main sections on the teaching page.
- Wrap the teaching philosophy sentence in a `<p>` tag to ensure proper paragraph semantics and spacing next to the table.
- Convert the markdown bullet sections under `Teaching formats` and `Supervision` into HTML `<ul><li>` lists to avoid mixed markdown/HTML rendering issues.
- Updated file: `_pages/teaching.html`.

### Testing
- Ran `rg -n "^## " _pages/teaching.html` to confirm no literal markdown `##` headings remain, which succeeded (no matches).
- Inspected changes with `git diff -- _pages/teaching.html` to verify the implemented edits, which succeeded.
- Ran `bundle exec jekyll build` to validate a site build, which failed because the `jekyll` executable is not installed in this environment.
- Attempted an automated Playwright screenshot of `http://127.0.0.1:4000/teaching/`, which failed with `net::ERR_EMPTY_RESPONSE` because no local site server was running.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699775f3e3848330b5944338d10ee234)