### PR TITLE
Add Blog index and sample post; prefer citation in archive titles

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -11,6 +11,9 @@ main:
   - title: "Publications"
     url: /publications/
 
+  - title: "Blog"
+    url: /blog/
+
   - title: "Teaching"
     url: /teaching/
 

--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -30,11 +30,12 @@
       </div>
     {% endif %}
 
+    {% assign display_title = post.citation | default: title %}
     <div class="archive__item-title" itemprop="headline">
       {% if post.link %}
-        <a href="{{ post.link }}">{{ post.citation }}</a> <a href="{{ base_path }}{{ post.url }}" rel="permalink"><i class="fa fa-link" aria-hidden="true" title="permalink"></i><span class="sr-only">Permalink</span></a>
+        <a href="{{ post.link }}">{{ display_title }}</a> <a href="{{ base_path }}{{ post.url }}" rel="permalink"><i class="fa fa-link" aria-hidden="true" title="permalink"></i><span class="sr-only">Permalink</span></a>
       {% else %}
-        <a href="{{ base_path }}{{ post.url }}" rel="permalink">{{ post.citation }}</a>
+        <a href="{{ base_path }}{{ post.url }}" rel="permalink">{{ display_title }}</a>
       {% endif %}
     </div>
     

--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -1,0 +1,13 @@
+---
+layout: archive
+title: "Blog"
+permalink: /blog/
+author_profile: true
+---
+
+A collection of all blog entries in reverse chronological order.
+
+{% include base_path %}
+{% for post in site.posts %}
+  {% include archive-single.html %}
+{% endfor %}

--- a/_posts/2026-02-25-human-centered-xr-metrics.md
+++ b/_posts/2026-02-25-human-centered-xr-metrics.md
@@ -1,0 +1,37 @@
+---
+title: "Why Human-Centered XR Metrics Matter"
+date: 2026-02-25
+permalink: /posts/2026/02/human-centered-xr-metrics/
+tags:
+  - extended reality
+  - quality of experience
+  - psychophysiology
+  - digital health
+---
+
+Extended Reality (XR) systems are often evaluated by technical performance alone
+(frame rate, latency, tracking precision). Those metrics are essential, but they
+are not enough to explain whether an experience is actually usable, engaging,
+and safe for people in real-world scenarios.
+
+In our research, we therefore combine **subjective** and **objective**
+measurements:
+
+- **Subjective measures**: standardized questionnaires on Quality of Experience
+  (QoE), usability, presence, workload, and simulator sickness.
+- **Objective measures**: behavioral logs (task completion time, error rates,
+  interaction traces) and psychophysiological signals (e.g., heart-rate
+  variability and skin conductance).
+
+This integrated view helps answer practical questions such as:
+
+1. Which interaction technique supports both high performance and low cognitive
+   load?
+2. How stable are user responses across different contexts (learning,
+   training, digital health)?
+3. Which signals can serve as reliable proxies for experience quality in
+   longitudinal studies?
+
+Over the next blog posts, I will share short insights from ongoing work on
+human-centered XR evaluation and how these findings can inform the design of
+future immersive systems.


### PR DESCRIPTION
### Motivation
- Add a dedicated blog index and navigation entry so blog posts are discoverable at `/blog/`.
- Ensure archive listings display a publication citation when available, falling back to the post title for clearer item labels.

### Description
- Added a `Blog` entry to `_data/navigation.yml` to expose the blog index in the main site navigation.
- Created a blog index page at `_pages/blog.md` using the `archive` layout that iterates over `site.posts` to render posts.
- Added a sample post `_posts/2026-02-25-human-centered-xr-metrics.md` with front matter and content for the new blog.
- Updated `_includes/archive-single.html` to introduce `display_title = post.citation | default: title` and use `display_title` for archive links so citations are shown when present.

### Testing
- Ran `bundle exec jekyll build` to build the site and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f84fd472483309f61c1a614f23283)