### PR TITLE
Improve on-site SEO: add JSON-LD, fix canonical, update metadata and robots

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ title_separator          : "-"
 name                     : &name "Prof. Dr.-Ing. Jan-Niklas Voigt-Antons"
 description              : &description "Prof. Dr.-Ing. Jan-Niklas Voigt-Antons — Professor of Computer Science (Immersive Media) at HSHL. Research on XR, Quality of Experience, psychophysiology, and digital health. 2,700+ citations, 210+ publications."
 url                      : https://voigt-antons.de # the base hostname & protocol for your site e.g. "https://mmistakes.github.io"
-baseurl                  : "/" # the subpath of your site, e.g. "/blog"
+baseurl                  : "" # the subpath of your site, e.g. "/blog"
 repository               : "jantons/voigt-antons.de"
 
 # Site Author - The following control what appear as part of the author content on the side bar.
@@ -27,7 +27,7 @@ author:
   bio              : "Hamm-Lippstadt University of Applied Sciences"
   location         : "Hamm - Lippstadt - Berlin, Germany"
   employer         : # DATA 
-  uri              : "https://www.voigt-antons.de/" 
+  uri              : "https://voigt-antons.de/"
   email            : "jan-niklas@voigt-antons.de" 
 
   # Academic websites

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -8,9 +8,9 @@
 
   <div class="author__avatar">
     {% if author.avatar contains "://" %}
-    	<img src="{{ author.avatar }}" alt="{{ author.name }}">
+      <img src="{{ author.avatar }}" alt="{{ author.name }}" width="427" height="428" loading="eager" fetchpriority="high" decoding="async">
     {% else %}
-    	<img src="{{ author.avatar | prepend: "/images/" | prepend: base_path }}" class="author__avatar" alt="{{ author.name }}">
+      <img src="{{ author.avatar | prepend: "/images/" | prepend: base_path }}" class="author__avatar" alt="{{ author.name }}" width="427" height="428" loading="eager" fetchpriority="high" decoding="async">
     {% endif %}
   </div>
 

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -31,30 +31,81 @@
 <script defer src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 
-
+{% if page.url == "/" %}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
   "@type": "Person",
-  "name": "Prof. Dr.-Ing. Jan-Niklas Voigt-Antons",
+  "@id": "https://voigt-antons.de/#person",
+  "name": "Jan-Niklas Voigt-Antons",
+  "honorificPrefix": "Prof. Dr.-Ing.",
+  "givenName": "Jan-Niklas",
+  "familyName": "Voigt-Antons",
+  "url": "https://voigt-antons.de/",
+  "image": "https://voigt-antons.de/images/profile.png",
+  "email": "jan-niklas@voigt-antons.de",
   "jobTitle": "Professor of Computer Science (Immersive Media)",
-  "affiliation": {
-    "@type": "CollegeOrUniversity",
-    "name": "Hamm-Lippstadt University of Applied Sciences"
-  },
-  "areaServed": ["Germany", "European Union"],
-  "knowsAbout": ["XR", "Spatial Interaction", "Quality of Experience", "Psychophysiology", "Digital Health"],
+  "description": "Professor für Informatik (Immersive Media) an der Hochschule Hamm-Lippstadt. Forschungsschwerpunkte: Extended Reality, Quality of Experience, Psychophysiologie und Digital Health.",
   "sameAs": [
-    "https://scholar.google.com/citations?user=IFIaOZsAAAAJ",
+    "https://scholar.google.de/citations?user=IFIaOZsAAAAJ",
     "https://orcid.org/0000-0002-2786-9262",
+    "https://github.com/jantons",
+    "https://www.linkedin.com/in/jnvoigtantons",
     "https://dblp.org/pid/39/10762",
-    "https://dl.acm.org/profile/99659317387",
-    "https://www.linkedin.com/in/jnvoigtantons/",
-    "https://immersive-reality-lab.de/pages/team_voigtantons.html",
-    "https://www.hshl.de/personen/prof-dr-ing-jan-niklas-voigt-antons"
+    "https://dl.acm.org/profile/99659317387"
   ],
-  "url": "https://voigt-antons.de/"
+  "worksFor": {
+    "@type": "EducationalOrganization",
+    "@id": "https://www.hshl.de/#organization",
+    "name": "Hamm-Lippstadt University of Applied Sciences",
+    "alternateName": "HSHL",
+    "url": "https://www.hshl.de"
+  },
+  "affiliation": {
+    "@type": "ResearchOrganization",
+    "name": "Immersive Reality Lab",
+    "url": "https://immersive-reality-lab.de"
+  },
+  "knowsAbout": [
+    "Extended Reality",
+    "Virtual Reality",
+    "Quality of Experience",
+    "Psychophysiology",
+    "Digital Health",
+    "Human-Computer Interaction",
+    "Immersive Media"
+  ],
+  "address": {
+    "@type": "PostalAddress",
+    "addressLocality": "Hamm",
+    "addressRegion": "Nordrhein-Westfalen",
+    "addressCountry": "DE"
+  }
 }
 </script>
+{% endif %}
+
+{% unless page.url == "/" %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://voigt-antons.de/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "{{ page.title | default: site.title | escape }}",
+      "item": "{{ page.url | prepend: site.url | replace: 'index.html', '' }}"
+    }
+  ]
+}
+</script>
+{% endunless %}
 
 <!-- end custom head snippets -->

--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -134,7 +134,7 @@
         {
           "@type": "ListItem",
           "position": 1,
-          "name": "About",
+          "name": "Home",
           "item": "{{ site.url }}/"
         },
         {

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,6 +1,6 @@
 ---
 permalink: /
-title: "About"
+title: "XR-Forscher & Professor für Immersive Media"
 author_profile: true
 description: "Prof. Dr.-Ing. Jan-Niklas Voigt-Antons: Human-centered XR and experience measurement for spatial interaction, learning, training, digital health, and immersive media research."
 redirect_from: 

--- a/robots.txt
+++ b/robots.txt
@@ -1,6 +1,8 @@
 User-agent: *
 Allow: /
 Disallow: /search/
+Disallow: /markdown/
+Disallow: /portfolio/
 
 # Explicitly allow AI crawlers
 User-agent: GPTBot


### PR DESCRIPTION
### Motivation
- Fix weak on-page SEO signals and missing structured data to improve indexing, Knowledge Graph eligibility and social previews.  
- Remove mixed `www` vs non-`www` references to prevent canonical/duplicate-content issues.  
- Reduce CLS and improve image semantics for the author profile and remove unwanted orphan pages from crawler index.

### Description
- Updated homepage H1/title to a keyword-rich headline in `_pages/about.md` to improve primary-topic relevance.  
- Normalized canonical/domain settings in `_config.yml` by setting `baseurl` to empty and changing the author `uri` to the non-`www` domain.  
- Added richer `Person` JSON-LD for the homepage and a `BreadcrumbList` JSON-LD for inner pages in `_includes/head/custom.html`.  
- Adjusted breadcrumb label from `About` to `Home` in `_includes/seo.html` to improve schema consistency.  
- Improved author avatar markup in `_includes/author-profile.html` by adding explicit `width`/`height` and `loading`/`fetchpriority`/`decoding` hints to reduce layout shift.  
- Extended `robots.txt` to disallow `/markdown/` and `/portfolio/` while keeping the `Sitemap` entry for discoverability.

### Testing
- Ran `git diff --check` which returned no warnings and confirmed whitespace issues were resolved (success).  
- Attempted `bundle exec jekyll build` to validate site build but it failed because the `jekyll` executable is not available in the environment (environment limitation).  
- Attempted `bundle install` but it failed due to network/Rubygems access (`403 Forbidden`) so plugin installation and full local build could not be performed.  
- Attempted a Playwright visit/screenshot of `http://127.0.0.1:4000` but no local server was running (`ERR_EMPTY_RESPONSE`), so a runtime render check was not possible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0bc143e088330b71de09551b8427a)