### PR TITLE
Improve SEO structured data completeness and canonical footer URL

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
 {% include base_path %}
 
 <div class="page__footer-copyright">
-  &copy; {{ site.time | date: '%Y' }} {{ site.name | default: site.title }} - <a href="https://www.voigt-antons.de/impressum">Impressum.</a><br />
+  &copy; {{ site.time | date: '%Y' }} {{ site.name | default: site.title }} - <a href="https://voigt-antons.de/impressum">Impressum.</a><br />
   Site last updated {{ "now" | date: '%Y-%m-%d' %}}
 </div>

--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -230,6 +230,31 @@
 </script>
 {% endif %}
 
+
+{% if page.collection == 'posts' %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": {{ page.title | jsonify }},
+  "datePublished": "{{ page.date | date_to_xmlschema }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | date_to_xmlschema }}",
+  "author": {
+    "@type": "Person",
+    "@id": "https://voigt-antons.de/#person",
+    "name": "Jan-Niklas Voigt-Antons"
+  },
+  "url": "{{ page.url | absolute_url }}",
+  "publisher": {
+    "@type": "Person",
+    "name": "Jan-Niklas Voigt-Antons",
+    "url": "https://voigt-antons.de"
+  },
+  "description": {{ seo_description | jsonify }}
+}
+</script>
+{% endif %}
+
 {% if page.collection == 'publications' %}
 <script type="application/ld+json">
 {

--- a/_pages/faq.md
+++ b/_pages/faq.md
@@ -47,6 +47,22 @@ his profiles on LinkedIn, Google Scholar, or the HSHL website.
         "@type": "Answer",
         "text": "The Immersive Reality Lab at Hamm-Lippstadt University of Applied Sciences (HSHL) is directed by Prof. Voigt-Antons. It investigates how immersive technologies can be designed and evaluated to improve experience quality, task performance, and user trust."
       }
+    },
+    {
+      "@type": "Question",
+      "name": "What is Quality of Experience (QoE)?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Quality of Experience is a research field that links technical system behavior (e.g., network latency, resolution) to how users perceive and rate their experience. Prof. Voigt-Antons develops QoE methods for immersive and cloud-based media systems."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How can I collaborate with or contact Jan-Niklas Voigt-Antons?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "You can reach Prof. Voigt-Antons via email at jan-niklas@voigt-antons.de or through his profiles on LinkedIn, Google Scholar, or the HSHL website."
+      }
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Ensure the site exposes raw structured data (JSON-LD) that can be validated in a browser / with Google Rich Results, and to make FAQ and blog posts eligible for rich results. 
- Replace non-canonical `www` footer link with the canonical non-`www` domain to avoid mixed-domain signals.

### Description
- Expanded the `FAQPage` JSON-LD to include all four questions/answers visible on the page so the structured data mirrors the on-page content (`_pages/faq.md`).
- Added a `BlogPosting` JSON-LD block for blog posts to `_includes/seo.html` under the condition `page.collection == 'posts'` with `headline`, `datePublished`, `dateModified`, `author`, `publisher`, `url` and `description`.
- Replaced the footer `Impressum` link from `https://www.voigt-antons.de/impressum` to the canonical `https://voigt-antons.de/impressum` in `_includes/footer.html`.
- Did not modify files that do not exist in this repo (`_pages/markdown.md` and `_pages/portfolio.md`) and left the existing homepage `Person` JSON-LD intact (already present in `_includes/head/custom.html`).

### Testing
- Verified file edits and patterns with ripgrep: `rg -n "https://voigt-antons.de/impressum|BlogPosting|What is Quality of Experience|How can I collaborate" _includes/footer.html _includes/seo.html _pages/faq.md` (matched updated content).
- Attempted a local site build with `bundle exec jekyll build`, which failed because `jekyll` is not installed in the environment (missing gem executable).
- Attempted `bundle install` to install dependencies, which failed due to network/rubygems access returning `403 Forbidden` in this environment.
- Captured a browser screenshot using the internal Playwright tool after loading `https://voigt-antons.de` (artifact: `browser:/tmp/codex_browser_invocations/e51c56259dd5aed2/artifacts/artifacts/voigt-home.png`).
- External `curl`/HTTP checks from this environment returned `CONNECT tunnel failed, response 403`, so a raw external `curl` HTML fetch could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0c4ae13fc83309e96d9b48d6c46ea)