### PR TITLE
Remove duplicate BreadcrumbList JSON-LD from custom head include

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -85,27 +85,4 @@
 </script>
 {% endif %}
 
-{% unless page.url == "/" %}
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "Home",
-      "item": "https://voigt-antons.de/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "{{ page.title | default: site.title | escape }}",
-      "item": "{{ page.url | prepend: site.url | replace: 'index.html', '' }}"
-    }
-  ]
-}
-</script>
-{% endunless %}
-
 <!-- end custom head snippets -->


### PR DESCRIPTION
### Motivation
- Non-home pages (e.g. `/faq/`) contained two `BreadcrumbList` JSON-LD blocks coming from both `_includes/seo.html` and `_includes/head/custom.html`, which is redundant and should be cleaned up.

### Description
- Deleted the `BreadcrumbList` JSON-LD block from `_includes/head/custom.html` so the canonical breadcrumb schema in `_includes/seo.html` remains the single source of breadcrumb JSON-LD.

### Testing
- Ran `rg -n '"@type": "BreadcrumbList"|itemtype="http://schema.org/BreadcrumbList"' _includes _pages` and confirmed the only JSON-LD `BreadcrumbList` now appears in `_includes/seo.html`, and the command returned the expected results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0c9ea126c8330b7093487b6bc601a)