### PR TITLE
Use HTTPS schema.org context in SEO JSON-LD

### DIFF
--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -104,7 +104,7 @@
 {% if site.og_image %}
   <script type="application/ld+json">
     {
-      "@context": "http://schema.org",
+      "@context": "https://schema.org",
       "@type": "Organization",
       "url": {{ seo_url | jsonify }},
       "logo": {{ site.og_image | prepend: "/images/" | prepend: base_path | jsonify }}
@@ -115,7 +115,7 @@
 {% if site.social %}
   <script type="application/ld+json">
     {
-      "@context" : "http://schema.org",
+      "@context" : "https://schema.org",
       "@type" : "{% if site.social.type %}{{ site.social.type }}{% else %}Person{% endif %}",
       "name" : "{{ site.social.name | default: site.name }}",
       "url" : {{ seo_url | jsonify }},


### PR DESCRIPTION
### Motivation
- Ensure JSON-LD `@context` uses the current standard `https://schema.org` because Block 0 contained `http://schema.org` which is outdated.

### Description
- Replace `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0c9f8ffe4833098377ef35df85633)