### PR TITLE
Consolidate homepage Person JSON-LD to a single canonical schema

### DIFF
--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -112,17 +112,10 @@
   </script>
 {% endif %}
 
-{% if site.social %}
-  <script type="application/ld+json">
-    {
-      "@context" : "http://schema.org",
-      "@type" : "{% if site.social.type %}{{ site.social.type }}{% else %}Person{% endif %}",
-      "name" : "{{ site.social.name | default: site.name }}",
-      "url" : {{ seo_url | jsonify }},
-      "sameAs" : {{ site.social.links | jsonify }}
-    }
-  </script>
-{% endif %}
+{% comment %}
+  Disabled the legacy theme `site.social` Person schema block to avoid duplicate
+  and conflicting Person definitions on the homepage.
+{% endcomment %}
 
 
 {% if page.url and page.url != "/" %}
@@ -180,55 +173,10 @@
 }
 </script>
 
-{% if page.url == "/" %}
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "Person",
-  "@id": "https://voigt-antons.de/#person",
-  "name": "Jan-Niklas Voigt-Antons",
-  "honorificPrefix": "Prof. Dr.-Ing.",
-  "url": "https://voigt-antons.de",
-  "image": "https://voigt-antons.de/images/profile.png",
-  "email": "jan-niklas@voigt-antons.de",
-  "jobTitle": "Professor of Computer Science (Immersive Media)",
-  "worksFor": {
-    "@type": "CollegeOrUniversity",
-    "name": "Hamm-Lippstadt University of Applied Sciences",
-    "alternateName": "HSHL",
-    "url": "https://www.hshl.de"
-  },
-  "affiliation": {
-    "@type": "ResearchOrganization",
-    "name": "Immersive Reality Lab",
-    "url": "https://immersive-reality-lab.de"
-  },
-  "alumniOf": [],
-  "knowsAbout": [
-    "Extended Reality (XR)",
-    "Quality of Experience (QoE)",
-    "Virtual Reality",
-    "Mixed Reality",
-    "Psychophysiology",
-    "Eye Tracking",
-    "Digital Health",
-    "Serious Games",
-    "Human-Computer Interaction",
-    "Spatial Interaction"
-  ],
-  "sameAs": [
-    "https://scholar.google.de/citations?user=IFIaOZsAAAAJ",
-    "https://orcid.org/0000-0002-2786-9262",
-    "https://dblp.org/pid/39/10762",
-    "https://dl.acm.org/profile/99659317387",
-    "https://www.linkedin.com/in/jnvoigtantons",
-    "https://github.com/jantons",
-    "https://www.hshl.de/personen/prof-dr-ing-jan-niklas-voigt-antons"
-  ],
-  "description": "Professor and researcher specializing in human-centered Extended Reality, Quality of Experience measurement, psychophysiology, and digital health. Director of the Immersive Reality Lab at HSHL."
-}
-</script>
-{% endif %}
+{% comment %}
+  Homepage Person schema is intentionally maintained in `_includes/head/custom.html`
+  to keep a single canonical Person entity definition with `@id`.
+{% endcomment %}
 
 
 {% if page.collection == 'posts' %}


### PR DESCRIPTION
### Motivation
- Google detected three competing `Person` JSON-LD blocks on the homepage (legacy theme block + two custom blocks), which weakens structured data signals and can introduce contradictions. 
- The intent is to disable the old theme-generated Person schema and keep a single, richer canonical Person entity with `@id` in the custom head include.

### Description
- Disabled the legacy theme `site.social` Person JSON-LD block by replacing it with a Liquid comment in `_includes/seo.html` to avoid generating the old `http://schema.org` Person object.
- Removed the duplicate homepage `Person` JSON-LD block from `_includes/seo.html` and added a comment pointing to `_includes/head/custom.html` as the single source of truth for the homepage Person entity.
- Left the richer canonical homepage `Person` schema unchanged in `_includes/head/custom.html` (retaining `@id`, `givenName`, `familyName`, `description`, `worksFor`, etc.).
- Added explanatory comments in `_includes/seo.html` to document why the legacy blocks were disabled.

### Testing
- Ran `rg -n '"@type"\s*:\s*"Person"|site.social|page.url == "/"' _includes/seo.html _includes/head/custom.html` to locate Person/schema blocks and confirmed the full Person definition is only present in `_includes/head/custom.html` while `_includes/seo.html` now only contains references and comments (test succeeded).
- Inspected the modified `_includes/seo.html` with `nl` to verify the legacy blocks were removed and comments inserted (inspection succeeded).
- Attempted `bundle exec jekyll build` to validate the site build, but the command failed in this environment because the `jekyll` executable is not installed, so a full build verification could not be completed (build validation failed due to missing tooling).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0ca15a64c83308daa66f19c460f88)