### PR TITLE
Kontaktseite: Meta-Description erweitern (SEO)

### DIFF
--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -3,7 +3,7 @@ layout: archive
 title: "Contact"
 permalink: /contact/
 author_profile: true
-description: "Contact details for Prof. Dr.-Ing. Jan-Niklas Voigt-Antons."
+description: "Contact Prof. Dr.-Ing. Jan-Niklas Voigt-Antons at Hamm-Lippstadt University of Applied Sciences (HSHL), Director of the Immersive Reality Lab, for research in XR, Quality of Experience, psychophysiology, and digital health."
 ---
 
 ## Contact details


### PR DESCRIPTION
### Motivation
- Die Meta-Description der Kontaktseite war zu kurz und wurde erweitert, um Institution, Rolle, Ort und Forschungsgebiete sichtbar zu machen und dadurch das SEO-Potenzial besser zu nutzen.

### Description
- Aktualisiert die `description`-Frontmatter in ` _pages/contact.md ` auf `"Contact Prof. Dr.-Ing. Jan-Niklas Voigt-Antons at Hamm-Lippstadt University of Applied Sciences (HSHL), Director of the Immersive Reality Lab, for research in XR, Quality of Experience, psychophysiology, and digital health."`.

### Testing
- Verifiziert, dass nur die Datei ` _pages/contact.md ` geändert wurde, die neue Beschreibung `223` Zeichen lang ist und die Repository-Diff/Status-Checks erwartungsgemäß erfolgreich waren.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0cd057ff883308f78bd920dab75c1)