### PR TITLE
Ungewollte Template- und interne Seiten aus Sitemap/öffentlicher Ausgabe ausschließen

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -189,6 +189,8 @@ exclude:
   - package.json*
   - Rakefile
   - README
+  - CODEBASE_REVIEW.md
+  - markdown_generator
   - tmp
   - vendor
 keep_files:

--- a/_pages/archive-layout-with-content.md
+++ b/_pages/archive-layout-with-content.md
@@ -2,6 +2,8 @@
 title: "Archive Layout with Content"
 layout: archive
 permalink: /archive-layout-with-content/
+sitemap: false
+published: false
 ---
 
 A variety of common markup showing how the theme styles them.

--- a/_pages/collection-archive.html
+++ b/_pages/collection-archive.html
@@ -1,4 +1,6 @@
 ---
+sitemap: false
+published: false
 layout: archive
 title: "Posts by Collection"
 permalink: /collection-archive/

--- a/_pages/non-menu-page.md
+++ b/_pages/non-menu-page.md
@@ -1,4 +1,6 @@
 ---
+sitemap: false
+published: false
 permalink: /non-menu-page/
 title: "Page not in menu"
 author_profile: true

--- a/_pages/page-archive.html
+++ b/_pages/page-archive.html
@@ -1,4 +1,6 @@
 ---
+sitemap: false
+published: false
 layout: archive
 title: "Page Archive"
 permalink: /page-archive/

--- a/_pages/sitemap.md
+++ b/_pages/sitemap.md
@@ -1,4 +1,6 @@
 ---
+sitemap: false
+published: false
 layout: archive
 title: "Sitemap"
 permalink: /sitemap/

--- a/_pages/year-archive.html
+++ b/_pages/year-archive.html
@@ -1,4 +1,6 @@
 ---
+sitemap: false
+published: false
 layout: archive
 permalink: /year-archive/
 title: "Blog posts"

--- a/_portfolio/portfolio-1.md
+++ b/_portfolio/portfolio-1.md
@@ -1,4 +1,6 @@
 ---
+sitemap: false
+published: false
 title: "Multimodal Interactive Assistance for Digital PROM Collection"
 excerpt: "Research project on accessible, AI-supported collection of patient-reported outcome measures (PROMs)."
 collection: portfolio

--- a/_portfolio/portfolio-2.html
+++ b/_portfolio/portfolio-2.html
@@ -1,4 +1,6 @@
 ---
+sitemap: false
+published: false
 title: "DIDYMOS-XR: Dynamic and Responsible Digital Twins for XR"
 excerpt: "EU-funded project on large-scale, synchronized digital twins for advanced XR applications."
 collection: portfolio


### PR DESCRIPTION
### Motivation
- Verhindern, dass Theme-Demos, technische Artefakte und interne Tools in der Sitemap landen oder öffentlich indexiert werden. 
- Portfolio-Unterseiten, die erreichbar sind, aber nicht veröffentlicht werden sollen, aus der öffentlichen Ausgabe entfernen. 
- Interne Dateien/Ordner aus dem Jekyll-Build ausschließen, damit sie nicht generiert oder indexiert werden.

### Description
- Für die Demo-/Template-Seiten `_pages/archive-layout-with-content.md`, `_pages/collection-archive.html`, `_pages/page-archive.html`, `_pages/year-archive.html`, `_pages/non-menu-page.md` und `_pages/sitemap.md` jeweils `sitemap: false` und `published: false` zum Frontmatter ergänzt. 
- Für die Portfolio-Detailseiten `_portfolio/portfolio-1.md` und `_portfolio/portfolio-2.html` ebenfalls `sitemap: false` und `published: false` gesetzt. 
- `_config.yml`-`exclude` erweitert um `CODEBASE_REVIEW.md` und `markdown_generator`, damit diese internen Ressourcen nicht vom Site-Build verarbeitet werden. 
- Änderungen wurden in einem Commit gespeichert (`c439941`).

### Testing
- Frontmatter-Prüfungen per `rg`/`sed` wurden ausgeführt und bestätigten das Vorhandensein von `sitemap: false` und `published: false` in allen Ziel-Dateien (erfolgreich). 
- Ein Versuch, die Seite mit `bundle exec jekyll build` zu bauen, schlug fehl, weil die Umgebung das `jekyll`-Executable nicht installiert hatte (`bundler: command not found: jekyll`). 
- Änderungen wurden mit `git commit` aufgezeichnet und die betroffenen Dateien sind im Commit enthalten (erfolgreich).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0cd235cdc8330ae4969c6d6563ace)