### PR TITLE
Disable legacy theme social Person schema output

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -141,14 +141,11 @@ og_image                 :  # Open Graph/Twitter default site image
 # For specifying social profiles
 # - https://developers.google.com/structured-data/customize/social-profiles
 social:
-  type                   : Person
-  name                   : "Prof. Dr.-Ing. Jan-Niklas Voigt-Antons"
-  links:
-    - https://scholar.google.de/citations?user=IFIaOZsAAAAJ
-    - https://orcid.org/0000-0002-2786-9262
-    - https://www.linkedin.com/in/jnvoigtantons/
-    - https://www.hshl.de/personen/prof-dr-ing-jan-niklas-voigt-antons
-    - https://immersive-reality-lab.de/pages/team_voigtantons.html
+  # Keep this block disabled to prevent legacy theme/person schema generation.
+  # The canonical Person JSON-LD is maintained in `_includes/head/custom.html`.
+  type                   :
+  name                   :
+  links: []
 
 
 # Analytics


### PR DESCRIPTION
### Motivation
- The site was emitting multiple Person JSON-LD blocks which created duplicate/conflicting `Person` schema entries, and only the canonical block in `_includes/head/custom.html` should remain.
- Prevent automatic legacy/theme-generated Person schema from `_config.yml` so the homepage `@id`-anchored Person block is the single source of truth.

### Description
- Cleared the legacy `social` Person config in ` _config.yml` by emptying `type`, `name`, and `links` and added comments pointing to the canonical JSON-LD in `_includes/head/custom.html`.
- Inspected ` _includes/seo.html` and ` _includes/head/custom.html` to confirm the canonical Person JSON-LD location and ensure the change prevents older theme output from generating duplicates.
- Committed the change with the message `Disable legacy social Person schema config`.

### Testing
- Ran `rg` searches for Person/schema snippets and confirmed occurrences in ` _includes/seo.html` and ` _includes/head/custom.html` (succeeded).
- Viewed file contents with `sed` to validate the canonical Person block is in ` _includes/head/custom.html` (succeeded).
- Verified the config diff with `git diff -- _config.yml` and committed the update with `git commit` (succeeded).
- Attempted `bundle exec jekyll build --quiet` to fully validate output but it failed due to the environment missing `jekyll`/Bundler executables (expected failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0cd419f8c833098b91b30f6fb0a22)