### PR TITLE
Add Google site verification meta tag to homepage head

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -32,6 +32,7 @@
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 
 {% if page.url == "/" %}
+<meta name="google-site-verification" content="8a1ReWiyyKFpv-C9BRST_4ITD9Q-6SLFlTFyYhn_-pM" />
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",


### PR DESCRIPTION
### Motivation
- Allow Google to verify site ownership by adding the provided verification meta tag to the site's homepage `<head>` output.

### Description
- Inserted the meta tag `<meta name="google-site-verification" content="8a1ReWiyyKFpv-C9BRST_4ITD9Q-6SLFlTFyYhn_-pM" />` into `_includes/head/custom.html` inside the `if page.url == "/"` conditional so it is rendered only on the home page.

### Testing
- Verified the tag is present in the include using `nl -ba _includes/head/custom.html | sed -n '35,80p'` and confirmed the file update was applied successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0d02d7d5c8330bbed05313ba7dfc8)