### PR TITLE
Redesign about page into structured profile layout and add supporting styles

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,55 +1,151 @@
 ---
+layout: single
 permalink: /
 title: "XR Researcher & Professor of Immersive Media"
 author_profile: true
 description: "Prof. Dr.-Ing. Jan-Niklas Voigt-Antons: Human-centered XR and experience measurement for spatial interaction, learning, training, digital health, and immersive media research."
-redirect_from: 
+redirect_from:
   - /about/
   - /about.html
 ---
 
-**Prof. Dr.-Ing. Jan-Niklas Voigt-Antons** is a Professor of Computer Science
-(Immersive Media) at Hamm-Lippstadt University of Applied Sciences (HSHL) and
-Director of the Immersive Reality Lab. His research focuses on human-centered
-Extended Reality (XR), Quality of Experience (QoE) measurement, psychophysiological
-sensing, and digital health applications. With over 2,700 citations and 210+
-publications, his work bridges immersive technology design with rigorous
-user-experience evaluation. He contributes to ITU-T standardization efforts and
-collaborates internationally on XR research.
+<div class="section-block section-block--white" markdown="1">
+
+**Prof. Dr.-Ing. Jan-Niklas Voigt-Antons** is a Professor of Computer Science (Immersive Media) at Hamm-Lippstadt University of Applied Sciences (HSHL) and Director of the Immersive Reality Lab. His research focuses on human-centered Extended Reality (XR), Quality of Experience (QoE) measurement, psychophysiological sensing, and digital health applications. With over 2,700 citations and 210+ publications, his work bridges immersive technology design with rigorous user-experience evaluation. He contributes to ITU-T standardization efforts and collaborates internationally on XR research.
+
+</div>
+
+<div class="section-block section-block--light" markdown="1">
 
 ## Appointments & affiliation
 
-Professor of Computer Science (Immersive Media), Hamm-Lippstadt University of Applied Sciences (HSHL). Director, Immersive Reality Lab.
+<div class="affiliation-box" markdown="1">
 
-- [HSHL profile](https://www.hshl.de/personen/prof-dr-ing-jan-niklas-voigt-antons)
-- [Immersive Reality Lab profile](https://immersive-reality-lab.de/pages/team_voigtantons.html)
+**Professor of Computer Science (Immersive Media)**
 
-## Evidence snapshot
+Hamm-Lippstadt University of Applied Sciences (HSHL). Director, Immersive Reality Lab.
 
-- **2,700+ citations** ([Google Scholar](https://scholar.google.de/citations?user=IFIaOZsAAAAJ))
-- **210+ publications** ([Google Scholar publication list](https://scholar.google.de/citations?user=IFIaOZsAAAAJ&hl=de))
-- **Persistent research identity** ([ORCID](https://orcid.org/0000-0002-2786-9262), [DBLP](https://dblp.org/pid/39/10762), [ACM DL](https://dl.acm.org/profile/99659317387))
+<div class="links">
+<a href="https://www.hshl.de/personen/prof-dr-ing-jan-niklas-voigt-antons">HSHL profile</a> &nbsp;&nbsp;
+<a href="https://immersive-reality-lab.de/pages/team_voigtantons.html">Immersive Reality Lab profile</a>
+</div>
 
-## Research lines snapshot
+</div>
 
-{% for line in site.data.highlights.research_lines %}
-### {{ line.name }}
-{{ line.claim }}
+</div>
 
-**Keywords:** {{ line.keywords | join: ", " }}
+<div class="section-block section-block--white">
 
-[See outputs](/research/#{{ line.id }}){: .btn .btn--info}
-{% endfor %}
+<h2>Evidence snapshot</h2>
 
-[Research](/research/){: .btn .btn--primary}
-[Projects](/projects/){: .btn .btn--primary}
-[Contact](/contact/){: .btn .btn--primary}
+<div class="metrics-grid">
+  <div class="metric-card">
+    <a href="https://scholar.google.de/citations?user=IFIaOZsAAAAJ">
+      <span class="metric-number">2,700+</span>
+      <span class="metric-label">Citations</span>
+    </a>
+  </div>
+  <div class="metric-card">
+    <a href="https://scholar.google.de/citations?user=IFIaOZsAAAAJ&hl=de">
+      <span class="metric-number">210+</span>
+      <span class="metric-label">Publications</span>
+    </a>
+  </div>
+  <div class="metric-card">
+    <a href="https://orcid.org/0000-0002-2786-9262">
+      <span class="metric-number">ORCID</span>
+      <span class="metric-label">Persistent researcher ID</span>
+    </a>
+  </div>
+  <div class="metric-card">
+    <a href="https://dblp.org/pid/39/10762">
+      <span class="metric-number">DBLP</span>
+      <span class="metric-label">Computer science bibliography</span>
+    </a>
+  </div>
+</div>
 
-## Featured elsewhere
+</div>
 
-- [Official profile at HSHL](https://www.hshl.de/personen/prof-dr-ing-jan-niklas-voigt-antons)
-- [Google Scholar profile](https://scholar.google.de/citations?user=IFIaOZsAAAAJ)
-- [ORCID profile](https://orcid.org/0000-0002-2786-9262)
-- [DBLP profile](https://dblp.org/pid/39/10762)
-- [ACM author profile](https://dl.acm.org/profile/99659317387)
-- [Berlin Universities Publishing author page](https://berlinup.books.tu-berlin.de/en/autor_innen/jan-niklas-voigt-antons/)
+<div class="section-block section-block--light">
+
+<h2>Research lines snapshot</h2>
+
+<div class="research-card">
+  <h3>XR &amp; Spatial Interaction</h3>
+  <p>Natural spatial interaction in XR improves effectiveness and social acceptability in real contexts.</p>
+  <div class="keyword-tags">
+    <span class="keyword-tag">Embodied interaction</span>
+    <span class="keyword-tag">Social acceptability</span>
+    <span class="keyword-tag">Mixed reality</span>
+  </div>
+  <a href="/research/#xr-and-spatial-interaction" class="btn btn--primary">See outputs</a>
+</div>
+
+<div class="research-card">
+  <h3>Quality of Experience (QoE)</h3>
+  <p>QoE methods provide actionable evidence for optimizing immersive and cloud-based media systems.</p>
+  <div class="keyword-tags">
+    <span class="keyword-tag">Questionnaires</span>
+    <span class="keyword-tag">Network impairments</span>
+    <span class="keyword-tag">Statistical modeling</span>
+  </div>
+  <a href="/research/#quality-of-experience-qoe" class="btn btn--primary">See outputs</a>
+</div>
+
+<div class="research-card">
+  <h3>Psychophysiology &amp; Behavioral Measurement</h3>
+  <p>Physiological and behavioral signals complement self-reports for robust user-state assessment.</p>
+  <div class="keyword-tags">
+    <span class="keyword-tag">Eye tracking</span>
+    <span class="keyword-tag">Multimodal sensing</span>
+    <span class="keyword-tag">Workload</span>
+  </div>
+  <a href="/research/#psychophysiology-and-behavioral-measurement" class="btn btn--primary">See outputs</a>
+</div>
+
+<div class="research-card">
+  <h3>Digital Health &amp; Learning</h3>
+  <p>XR and serious-game approaches increase engagement and improve applied training outcomes.</p>
+  <div class="keyword-tags">
+    <span class="keyword-tag">Serious games</span>
+    <span class="keyword-tag">Health communication</span>
+    <span class="keyword-tag">Training</span>
+  </div>
+  <a href="/research/#digital-health-and-learning" class="btn btn--primary">See outputs</a>
+</div>
+
+<p>
+  <a href="/research/" class="btn btn--primary">Research</a>
+  <a href="/projects/" class="btn btn--primary">Projects</a>
+  <a href="/contact/" class="btn btn--primary">Contact</a>
+</p>
+
+</div>
+
+<div class="section-block section-block--white">
+
+<h2>Featured elsewhere</h2>
+
+<div class="profile-chips">
+  <a href="https://www.hshl.de/personen/prof-dr-ing-jan-niklas-voigt-antons" class="profile-chip">
+    <i class="fas fa-university" aria-hidden="true"></i> HSHL
+  </a>
+  <a href="https://scholar.google.de/citations?user=IFIaOZsAAAAJ" class="profile-chip">
+    <i class="fas fa-graduation-cap" aria-hidden="true"></i> Google Scholar
+  </a>
+  <a href="https://orcid.org/0000-0002-2786-9262" class="profile-chip">
+    <i class="fab fa-orcid" aria-hidden="true"></i> ORCID
+  </a>
+  <a href="https://dblp.org/pid/39/10762" class="profile-chip">
+    <i class="fas fa-database" aria-hidden="true"></i> DBLP
+  </a>
+  <a href="https://dl.acm.org/profile/99659317387" class="profile-chip">
+    <i class="fas fa-book" aria-hidden="true"></i> ACM DL
+  </a>
+  <a href="https://berlinup.books.tu-berlin.de/en/autor_innen/jan-niklas-voigt-antons/" class="profile-chip">
+    <i class="fas fa-university" aria-hidden="true"></i> BerlinUP
+  </a>
+</div>
+
+</div>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -39,3 +39,221 @@
 @import "vendor/font-awesome/brands";
 @import "vendor/magnific-popup/magnific-popup";
 @import "print";
+:root {
+  --color-primary: #52adc8;
+  --color-primary-dark: #3a8da8;
+  --color-primary-light: #e8f4f8;
+  --color-text: #2c3e50;
+  --color-text-muted: #5a6a7a;
+  --color-border: #e0e6eb;
+  --color-bg-subtle: #f8fafb;
+  --color-accent: #d4a847;
+  --color-accent-light: #faf5e8;
+  --font-heading: "Source Serif 4", "Georgia", serif;
+  --font-body: "Source Sans 3", "Helvetica Neue", sans-serif;
+}
+
+h1,
+h2 {
+  font-family: var(--font-heading);
+}
+
+body,
+p,
+li {
+  font-family: var(--font-body);
+}
+
+.page__content {
+  max-width: 720px;
+}
+
+.page__content h2 {
+  margin-top: 0;
+  margin-bottom: 1.25rem;
+  padding-bottom: 0.5rem;
+  border-bottom: none;
+  position: relative;
+}
+
+.page__content h2::after {
+  content: "";
+  display: block;
+  width: 50px;
+  height: 3px;
+  background: var(--color-primary);
+  margin-top: 0.5rem;
+  border-radius: 2px;
+}
+
+.page__content p {
+  margin-bottom: 1.1rem;
+  line-height: 1.7;
+}
+
+.btn--primary {
+  padding: 0.5rem 1.25rem;
+  border-radius: 4px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.section-block {
+  padding: 2.5rem 0;
+  margin: 0 -1.5rem;
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+}
+
+.section-block--light {
+  background: var(--color-bg-subtle);
+  border-top: 1px solid #eef2f5;
+  border-bottom: 1px solid #eef2f5;
+}
+
+.section-block--white {
+  background: #ffffff;
+}
+
+.affiliation-box {
+  background: linear-gradient(135deg, #f7fafb 0%, #eef4f7 100%);
+  border: 1px solid #dde8ed;
+  border-radius: 8px;
+  padding: 1.25rem 1.5rem;
+  margin: 1rem 0 1.5rem;
+}
+
+.affiliation-box .role {
+  font-weight: 600;
+  color: var(--color-text);
+  font-size: 1rem;
+}
+
+.affiliation-box .institution {
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+  margin-top: 0.25rem;
+}
+
+.affiliation-box .links {
+  margin-top: 0.75rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.affiliation-box .links a {
+  font-size: 0.85rem;
+  color: var(--color-primary);
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0 2rem;
+}
+
+.metric-card {
+  background: #f7fafb;
+  border: 1px solid #e4ecf0;
+  border-radius: 6px;
+  padding: 1.25rem 1rem;
+  text-align: center;
+}
+
+.metric-card .metric-number {
+  display: block;
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: var(--color-primary);
+  line-height: 1.2;
+}
+
+.metric-card .metric-label {
+  display: block;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  margin-top: 0.25rem;
+}
+
+.metric-card a {
+  text-decoration: none;
+  color: inherit;
+}
+
+.metric-card a:hover .metric-number {
+  color: var(--color-primary-dark);
+}
+
+.research-card {
+  background: #ffffff;
+  border: 1px solid #e8ecf0;
+  border-left: 4px solid var(--color-primary);
+  border-radius: 6px;
+  padding: 1.5rem 1.75rem;
+  margin-bottom: 1.5rem;
+  transition: box-shadow 0.2s ease, transform 0.15s ease;
+}
+
+.research-card:hover {
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  transform: translateY(-2px);
+}
+
+.research-card h3,
+.research-card h4 {
+  margin-top: 0;
+  color: var(--color-text);
+}
+
+.research-card .keyword-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0.75rem 0;
+}
+
+.research-card .keyword-tag {
+  background: #f0f7fa;
+  color: #3a8da8;
+  font-size: 0.8rem;
+  padding: 0.25rem 0.65rem;
+  border-radius: 3px;
+  font-weight: 500;
+  border: 1px solid #d4e8ef;
+}
+
+.profile-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin: 1rem 0;
+}
+
+.profile-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 1rem;
+  background: #ffffff;
+  border: 1px solid #dde4ea;
+  border-radius: 20px;
+  font-size: 0.85rem;
+  color: #3a5a6f;
+  text-decoration: none;
+  transition: all 0.2s ease;
+  font-weight: 500;
+}
+
+.profile-chip:hover {
+  background: #f0f7fa;
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  box-shadow: 0 2px 8px rgba(82, 173, 200, 0.15);
+}
+
+
+.section-block h2 {
+  margin-top: 0;
+}


### PR DESCRIPTION
### Motivation

- Convert the single-page about content into a structured, componentized profile layout to improve readability and surface key researcher metrics and links. 
- Provide consistent styling for new content blocks (affiliation, metrics, research cards, profile chips) and align typography with site variables.

### Description

- Reworked `_pages/about.md` to use `layout: single` and replaced the plain markdown list with structured HTML blocks: `.section-block`, `.affiliation-box`, `.metrics-grid`, `.research-card`, and `.profile-chips`. 
- Added evidence snapshot, research line cards, quick action buttons, and external profile links while preserving original links and citation/publication references. 
- Removed the original Liquid research lines loop output in favor of static card-based presentation for the highlighted research areas. 
- Extended `assets/css/main.scss` with CSS custom properties, font-family variables, and comprehensive styles for the new UI components and layout rules used on the about page.

### Testing

- Built the site with `bundle exec jekyll build` to validate page generation and the new layout, and the build completed successfully. 
- Compiled the SCSS and verified stylesheet generation without errors (SCSS compilation succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a48e659b388330957b5eea5c5f37b4)