### PR TITLE
Apply About page section styling to main site pages

### DIFF
--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -5,9 +5,15 @@ permalink: /blog/
 author_profile: true
 ---
 
+<div class="section-block section-block--white" markdown="1">
+
 A collection of all blog entries in reverse chronological order.
 
+</div>
+
+<div class="section-block section-block--light">
 {% include base_path %}
 {% for post in site.posts %}
   {% include archive-single.html %}
 {% endfor %}
+</div>

--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -6,18 +6,32 @@ author_profile: true
 description: "Contact Prof. Dr.-Ing. Jan-Niklas Voigt-Antons at Hamm-Lippstadt University of Applied Sciences (HSHL), Director of the Immersive Reality Lab, for research in XR, Quality of Experience, psychophysiology, and digital health."
 ---
 
+<div class="section-block section-block--white" markdown="1">
+
 ## Contact details
+
+<div class="affiliation-box" markdown="1">
 
 - **Email:** [jan-niklas@voigt-antons.de](mailto:jan-niklas@voigt-antons.de)
 - **Affiliation:** Hamm-Lippstadt University of Applied Sciences (HSHL)
 - **Role:** Director, Immersive Reality Lab
 - **Location:** Hamm / Lippstadt / Berlin, Germany
 
+</div>
+
+</div>
+
+<div class="section-block section-block--light" markdown="1">
+
 ## Profiles
 
-- [HSHL profile](https://www.hshl.de/personen/prof-dr-ing-jan-niklas-voigt-antons)
-- [Immersive Reality Lab](https://immersive-reality-lab.de/pages/team_voigtantons.html)
-- [Google Scholar](https://scholar.google.com/citations?user=IFIaOZsAAAAJ)
-- [ORCID](https://orcid.org/0000-0002-2786-9262)
-- [DBLP](https://dblp.org/pid/39/10762)
-- [LinkedIn](https://www.linkedin.com/in/jnvoigtantons/)
+<div class="profile-links">
+  <a href="https://www.hshl.de/personen/prof-dr-ing-jan-niklas-voigt-antons" class="profile-chip"><i class="fas fa-university" aria-hidden="true"></i> HSHL</a>
+  <a href="https://immersive-reality-lab.de/pages/team_voigtantons.html" class="profile-chip"><i class="fas fa-vr-cardboard" aria-hidden="true"></i> Immersive Reality Lab</a>
+  <a href="https://scholar.google.com/citations?user=IFIaOZsAAAAJ" class="profile-chip"><i class="fas fa-graduation-cap" aria-hidden="true"></i> Google Scholar</a>
+  <a href="https://orcid.org/0000-0002-2786-9262" class="profile-chip"><i class="fab fa-orcid" aria-hidden="true"></i> ORCID</a>
+  <a href="https://dblp.org/pid/39/10762" class="profile-chip"><i class="fas fa-database" aria-hidden="true"></i> DBLP</a>
+  <a href="https://www.linkedin.com/in/jnvoigtantons/" class="profile-chip"><i class="fab fa-linkedin" aria-hidden="true"></i> LinkedIn</a>
+</div>
+
+</div>

--- a/_pages/cv.md
+++ b/_pages/cv.md
@@ -8,6 +8,8 @@ redirect_from:
   - /resume
 ---
 
+<div class="section-block section-block--white" markdown="1">
+
 [Download CV (PDF)](/files/cv.pdf){: .btn .btn--primary}
 
 ## Appointments
@@ -25,6 +27,10 @@ redirect_from:
 
 - Applied R&D with industry and public stakeholders in XR, digital twins, and human-centered system evaluation.
 - Transfer formats: prototypes, training modules, workshops, and pilot deployments.
+
+</div>
+
+<div class="section-block section-block--light" markdown="1">
 
 ## Grants and projects (selected)
 
@@ -44,6 +50,10 @@ redirect_from:
 - Reviewing and service in venues including ACM CHI, IEEE ISMAR, ACM VRST, and QoMEX.
 - Standardization-related dissemination and invited talks.
 
+</div>
+
+<div class="section-block section-block--white" markdown="1">
+
 ## Selected publications
 
 - [Dynamic and Responsible Digital Twins for Extended Reality](/publication/2025-09-01-J32)
@@ -53,8 +63,12 @@ redirect_from:
 
 ## External profiles
 
-- [Google Scholar](https://scholar.google.com/citations?user=IFIaOZsAAAAJ)
-- [ORCID](https://orcid.org/0000-0002-2786-9262)
-- [DBLP](https://dblp.org/pid/39/10762)
-- [ACM author profile](https://dl.acm.org/profile/99659317387)
-- [HSHL profile](https://www.hshl.de/personen/prof-dr-ing-jan-niklas-voigt-antons)
+<div class="profile-links">
+  <a href="https://scholar.google.com/citations?user=IFIaOZsAAAAJ" class="profile-chip"><i class="fas fa-graduation-cap" aria-hidden="true"></i> Google Scholar</a>
+  <a href="https://orcid.org/0000-0002-2786-9262" class="profile-chip"><i class="fab fa-orcid" aria-hidden="true"></i> ORCID</a>
+  <a href="https://dblp.org/pid/39/10762" class="profile-chip"><i class="fas fa-database" aria-hidden="true"></i> DBLP</a>
+  <a href="https://dl.acm.org/profile/99659317387" class="profile-chip"><i class="fas fa-book" aria-hidden="true"></i> ACM author profile</a>
+  <a href="https://www.hshl.de/personen/prof-dr-ing-jan-niklas-voigt-antons" class="profile-chip"><i class="fas fa-university" aria-hidden="true"></i> HSHL profile</a>
+</div>
+
+</div>

--- a/_pages/faq.md
+++ b/_pages/faq.md
@@ -6,26 +6,31 @@ author_profile: true
 description: "Frequently asked questions about Jan-Niklas Voigt-Antons, research focus, QoE, and the Immersive Reality Lab."
 ---
 
+<div class="section-block section-block--white" markdown="1">
+
 ## Frequently Asked Questions
 
-### What is Jan-Niklas Voigt-Antons' research focus?
-Jan-Niklas Voigt-Antons researches human-centered Extended Reality (XR), including
-spatial interaction design, Quality of Experience measurement, psychophysiological
-sensing, and digital health applications using VR and serious games.
+<div class="research-card">
+<h3>What is Jan-Niklas Voigt-Antons' research focus?</h3>
+<p>Jan-Niklas Voigt-Antons researches human-centered Extended Reality (XR), including spatial interaction design, Quality of Experience measurement, psychophysiological sensing, and digital health applications using VR and serious games.</p>
+</div>
 
-### What is the Immersive Reality Lab?
-The Immersive Reality Lab at Hamm-Lippstadt University of Applied Sciences (HSHL)
-is directed by Prof. Voigt-Antons. It investigates how immersive technologies can
-be designed and evaluated to improve experience quality, task performance, and user trust.
+<div class="research-card">
+<h3>What is the Immersive Reality Lab?</h3>
+<p>The Immersive Reality Lab at Hamm-Lippstadt University of Applied Sciences (HSHL) is directed by Prof. Voigt-Antons. It investigates how immersive technologies can be designed and evaluated to improve experience quality, task performance, and user trust.</p>
+</div>
 
-### What is Quality of Experience (QoE)?
-Quality of Experience is a research field that links technical system behavior
-(e.g., network latency, resolution) to how users perceive and rate their experience.
-Prof. Voigt-Antons develops QoE methods for immersive and cloud-based media systems.
+<div class="research-card">
+<h3>What is Quality of Experience (QoE)?</h3>
+<p>Quality of Experience is a research field that links technical system behavior (e.g., network latency, resolution) to how users perceive and rate their experience. Prof. Voigt-Antons develops QoE methods for immersive and cloud-based media systems.</p>
+</div>
 
-### How can I collaborate with or contact Jan-Niklas Voigt-Antons?
-You can reach Prof. Voigt-Antons via email at jan-niklas@voigt-antons.de or through
-his profiles on LinkedIn, Google Scholar, or the HSHL website.
+<div class="research-card">
+<h3>How can I collaborate with or contact Jan-Niklas Voigt-Antons?</h3>
+<p>You can reach Prof. Voigt-Antons via email at jan-niklas@voigt-antons.de or through his profiles on LinkedIn, Google Scholar, or the HSHL website.</p>
+</div>
+
+</div>
 
 <script type="application/ld+json">
 {

--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -6,6 +6,8 @@ author_profile: true
 description: "Funded projects, roles, and transfer outcomes in XR, digital twins, QoE, and digital health."
 ---
 
+<div class="section-block section-block--white" markdown="1">
+
 ## Funding table
 
 | Project | Period | Funding program / funder | Role | Partners | Outputs |
@@ -13,22 +15,32 @@ description: "Funded projects, roles, and transfer outcomes in XR, digital twins
 {% for project in site.data.projects %}| [{{ project.name }}](#{{ project.id }}) | {{ project.period }} | {{ project.funding_program }} ({{ project.funder }}) | {{ project.role }} | {{ project.partners | join: ", " }} | {% for output in project.outputs %}[{{ output.label }}]({{ output.url }}){% unless forloop.last %}; {% endunless %}{% endfor %} |
 {% endfor %}
 
-## Project details
+</div>
+
+<div class="section-block section-block--light">
+
+<h2>Project details</h2>
 
 {% for project in site.data.projects %}
-### {{ project.name }} {#{{ project.id }}}
+<div class="research-card" id="{{ project.id }}">
+  <h3>{{ project.name }}</h3>
+  <p><strong>Period:</strong> {{ project.period }}</p>
+  <p><strong>Role:</strong> {{ project.role }}</p>
+  <p><strong>Funding:</strong> {{ project.funding_program }} / {{ project.funder }}</p>
+  <p><strong>Topics:</strong> {{ project.topics | join: ", " }}</p>
 
-- **Period:** {{ project.period }}
-- **Role:** {{ project.role }}
-- **Funding:** {{ project.funding_program }} / {{ project.funder }}
-- **Topics:** {{ project.topics | join: ", " }}
-
-**Evidence links**
-{% for link in project.evidence_links %}
-- [{{ link.label }}]({{ link.url }})
+  <p><strong>Evidence links</strong></p>
+  <ul>
+    {% for link in project.evidence_links %}
+    <li><a href="{{ link.url }}">{{ link.label }}</a></li>
+    {% endfor %}
+  </ul>
+</div>
 {% endfor %}
 
-{% endfor %}
+</div>
+
+<div class="section-block section-block--white" markdown="1">
 
 ## Transfer & industry
 
@@ -36,3 +48,5 @@ description: "Funded projects, roles, and transfer outcomes in XR, digital twins
 - Current portfolio includes **~{{ partner_sum }} partner engagements across public and industry contexts**.
 - Typical transfer formats: prototype demonstrators, stakeholder workshops, pilot deployments, and training-focused modules.
 - Current transfer focus areas: XR prototyping, digital twins, user-experience evaluation, and applied teaching innovation.
+
+</div>

--- a/_pages/publications.html
+++ b/_pages/publications.html
@@ -6,6 +6,8 @@ author_profile: true
 description: "Selected and complete publications with filtering by year, type, venue, and topic tags."
 ---
 
+<div class="section-block section-block--white" markdown="1">
+
 <div class="wordwrap"><strong>External profiles:</strong> <a href="https://scholar.google.com/citations?user=IFIaOZsAAAAJ">Google Scholar</a> · <a href="https://dblp.org/pid/39/10762">DBLP</a> · <a href="https://dl.acm.org/profile/99659317387">ACM DL</a> · <a href="https://orcid.org/0000-0002-2786-9262">ORCID</a></div>
 
 <h2>Selected publications</h2>
@@ -33,6 +35,10 @@ description: "Selected and complete publications with filtering by year, type, v
   <li><a href="https://berlinup.books.tu-berlin.de/en/autor_innen/jan-niklas-voigt-antons/">The digitalization of healthcare for older adults (book)</a></li>
   <li><a href="/publication/2024-10-16-BC4">Current and Future Trends in Human-Centered Digitalization in Healthcare (2024 editorship)</a></li>
 </ul>
+
+</div>
+
+<div class="section-block section-block--light">
 
 <h2>Filter all publications</h2>
 
@@ -69,6 +75,8 @@ description: "Selected and complete publications with filtering by year, type, v
     </article>
   </div>
 {% endfor %}
+</div>
+
 </div>
 
 <script>

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -6,6 +6,8 @@ author_profile: true
 description: "Research by Jan-Niklas Voigt-Antons on Extended Reality, spatial interaction, Quality of Experience, psychophysiological measurement, and digital health applications."
 ---
 
+<div class="section-block section-block--white" markdown="1">
+
 ## Research overview
 
 I investigate how immersive and interactive systems can be designed and evaluated to improve experience quality, task performance, and trust.
@@ -13,6 +15,8 @@ I investigate how immersive and interactive systems can be designed and evaluate
 ## What I Research (in plain language)
 
 I study how virtual and augmented reality systems can be built so they actually work well for people — not just technically, but in terms of how natural, comfortable, and useful they feel. My lab measures user experience using questionnaires, eye tracking, and physiological sensors, and applies these findings to improve VR/AR for training, healthcare, and everyday use.
+
+</div>
 
 <script type="application/ld+json">
 {
@@ -40,6 +44,8 @@ I study how virtual and augmented reality systems can be built so they actually 
 }
 </script>
 
+<div class="section-block section-block--light" markdown="1">
+
 ## Methods toolbox
 
 `Eye tracking` · `Physiological sensing` · `Behavioral coding` · `QoE questionnaires` · `Simulator studies` · `Statistical analysis` · `Multimodal fusion`
@@ -50,54 +56,74 @@ Related outputs: [Psychophysiology-tagged work](/publications/?topic=psychophysi
 
 Safety-critical training · Public-space MR · Digital twins · Health communication · Intelligent agents
 
-## XR & Spatial Interaction {#xr-spatial-interaction}
+</div>
 
-**Why it matters:** Spatial interaction quality directly influences usability, social acceptance, and deployment readiness.
+<div class="section-block section-block--white">
 
-**Representative outputs**
-- [Towards Socially Acceptable Virtual Reality Interactions in Public Contexts](/publication/2025-06-01-C89)
-- [A user study on physically active locomotion in social virtual reality](/publication/2025-01-01-J31)
-- [Perceptibility and Preference of Dynamic Weight Changes in Virtual Reality Through Pseudo-Haptic and Vibrotactile Cues](/publication/2024-12-01-C83)
+<h2>Research lines</h2>
 
-**Representative projects**
-- [Didymos-XR](/projects/#didymos-xr)
-- [ARiadne](/projects/#ariadne)
+<div class="research-card" id="xr-spatial-interaction">
+  <h3>XR &amp; Spatial Interaction</h3>
+  <p><strong>Why it matters:</strong> Spatial interaction quality directly influences usability, social acceptance, and deployment readiness.</p>
+  <p><strong>Representative outputs</strong></p>
+  <ul>
+    <li><a href="/publication/2025-06-01-C89">Towards Socially Acceptable Virtual Reality Interactions in Public Contexts</a></li>
+    <li><a href="/publication/2025-01-01-J31">A user study on physically active locomotion in social virtual reality</a></li>
+    <li><a href="/publication/2024-12-01-C83">Perceptibility and Preference of Dynamic Weight Changes in Virtual Reality Through Pseudo-Haptic and Vibrotactile Cues</a></li>
+  </ul>
+  <p><strong>Representative projects</strong></p>
+  <ul>
+    <li><a href="/projects/#didymos-xr">Didymos-XR</a></li>
+    <li><a href="/projects/#ariadne">ARiadne</a></li>
+  </ul>
+</div>
 
-## Quality of Experience (QoE) {#qoe}
+<div class="research-card" id="qoe">
+  <h3>Quality of Experience (QoE)</h3>
+  <p><strong>Why it matters:</strong> QoE data links technical system behavior to perceived quality, trust, and adoption.</p>
+  <p><strong>Representative outputs</strong></p>
+  <ul>
+    <li><a href="/publication/2024-10-10-C82">Impact of Packet Loss and Delay on Presence and User Experience in VR Cloud Gaming</a></li>
+    <li><a href="/publication/2025-09-01-J32">Dynamic and Responsible Digital Twins for Extended Reality</a></li>
+    <li><a href="/publication/2024-07-01-J29">A quality of experience approach for cloud gaming in virtual reality</a></li>
+  </ul>
+  <p><strong>Representative projects</strong></p>
+  <ul>
+    <li><a href="/projects/#didymos-xr">Didymos-XR</a></li>
+    <li><a href="/projects/#mia-prom">MIA-PROM</a></li>
+  </ul>
+</div>
 
-**Why it matters:** QoE data links technical system behavior to perceived quality, trust, and adoption.
+<div class="research-card" id="psychophysiology">
+  <h3>Psychophysiology &amp; Behavioral Measurement</h3>
+  <p><strong>Why it matters:</strong> Multimodal measurements help quantify user state beyond self-report alone.</p>
+  <p><strong>Representative outputs</strong></p>
+  <ul>
+    <li><a href="/publication/2023-03-02-J25">Arousal Effects on Evaluation and Perception in Multimedia Quality</a></li>
+    <li><a href="/publication/2025-03-01-C87">Assessing Social Acceptability in Immersive Environments</a></li>
+    <li><a href="/publication/2025-01-01-C84">User-centered measurements for immersive interaction quality</a></li>
+  </ul>
+  <p><strong>Representative projects</strong></p>
+  <ul>
+    <li><a href="/projects/#mia-prom">MIA-PROM</a></li>
+    <li><a href="/projects/#digiontrack">DigiOnTrack</a></li>
+  </ul>
+</div>
 
-**Representative outputs**
-- [Impact of Packet Loss and Delay on Presence and User Experience in VR Cloud Gaming](/publication/2024-10-10-C82)
-- [Dynamic and Responsible Digital Twins for Extended Reality](/publication/2025-09-01-J32)
-- [A quality of experience approach for cloud gaming in virtual reality](/publication/2024-07-01-J29)
+<div class="research-card" id="digital-health-learning">
+  <h3>Digital Health &amp; Learning</h3>
+  <p><strong>Why it matters:</strong> Human-centered XR can improve engagement and measurable outcomes in education and health communication.</p>
+  <p><strong>Representative outputs</strong></p>
+  <ul>
+    <li><a href="https://berlinup.books.tu-berlin.de/en/autor_innen/jan-niklas-voigt-antons/">The digitalization of healthcare for older adults (book editorship)</a></li>
+    <li><a href="/publications/">Immersive interview training and social interaction studies</a></li>
+    <li><a href="/publications/">Recent XR teaching-transfer publications</a></li>
+  </ul>
+  <p><strong>Representative projects</strong></p>
+  <ul>
+    <li><a href="/projects/#ariadne">ARiadne</a></li>
+    <li><a href="/projects/#virtuelles-institut-ar-vr">Virtuelles Institut AR/VR</a></li>
+  </ul>
+</div>
 
-**Representative projects**
-- [Didymos-XR](/projects/#didymos-xr)
-- [MIA-PROM](/projects/#mia-prom)
-
-## Psychophysiology & Behavioral Measurement {#psychophysiology}
-
-**Why it matters:** Multimodal measurements help quantify user state beyond self-report alone.
-
-**Representative outputs**
-- [Arousal Effects on Evaluation and Perception in Multimedia Quality](/publication/2023-03-02-J25)
-- [Assessing Social Acceptability in Immersive Environments](/publication/2025-03-01-C87)
-- [User-centered measurements for immersive interaction quality](/publication/2025-01-01-C84)
-
-**Representative projects**
-- [MIA-PROM](/projects/#mia-prom)
-- [DigiOnTrack](/projects/#digiontrack)
-
-## Digital Health & Learning {#digital-health-learning}
-
-**Why it matters:** Human-centered XR can improve engagement and measurable outcomes in education and health communication.
-
-**Representative outputs**
-- [The digitalization of healthcare for older adults (book editorship)](https://berlinup.books.tu-berlin.de/en/autor_innen/jan-niklas-voigt-antons/)
-- [Immersive interview training and social interaction studies](/publications/)
-- [Recent XR teaching-transfer publications](/publications/)
-
-**Representative projects**
-- [ARiadne](/projects/#ariadne)
-- [Virtuelles Institut AR/VR](/projects/#virtuelles-institut-ar-vr)
+</div>

--- a/_pages/service.md
+++ b/_pages/service.md
@@ -6,12 +6,22 @@ author_profile: true
 description: "Academic leadership, reviewing, program committees, standardization, and invited talks."
 ---
 
+<div class="section-block section-block--white" markdown="1">
+
 ## Leadership
+
+<div class="affiliation-box" markdown="1">
 
 - **{{ site.data.service.leadership.role }}**, Hamm-Lippstadt University of Applied Sciences.
 - **Mission:** {{ site.data.service.leadership.mission }}
 - **Team structure:** {{ site.data.service.leadership.team_structure }}
 - **Infrastructure:** {{ site.data.service.leadership.infrastructure | join: ", " }}
+
+</div>
+
+</div>
+
+<div class="section-block section-block--light" markdown="1">
 
 ## Reviewing and program committees (selected)
 
@@ -25,6 +35,10 @@ description: "Academic leadership, reviewing, program committees, standardizatio
 - {{ journal }}
 {% endfor %}
 
+</div>
+
+<div class="section-block section-block--white" markdown="1">
+
 ## Community and standardization
 
 {% for item in site.data.service.community %}
@@ -34,3 +48,5 @@ description: "Academic leadership, reviewing, program committees, standardizatio
 ## Invited talks and dissemination
 
 See [Talks and presentations](/talks/) for recent invited talks, conference contributions, and media appearances.
+
+</div>

--- a/_pages/teaching.html
+++ b/_pages/teaching.html
@@ -6,9 +6,15 @@ author_profile: true
 description: "Teaching portfolio in Virtual Reality, Augmented Reality, immersive systems design, and research-led project formats."
 ---
 
+<div class="section-block section-block--white">
+
 <h2>Teaching philosophy</h2>
 
 <p>I teach immersive technologies as a combination of technical implementation, human-centered design, and empirical evaluation.</p>
+
+</div>
+
+<div class="section-block section-block--light">
 
 <h2>Courses taught</h2>
 
@@ -37,6 +43,10 @@ description: "Teaching portfolio in Virtual Reality, Augmented Reality, immersiv
   </tbody>
 </table>
 
+</div>
+
+<div class="section-block section-block--white">
+
 <h2>Teaching formats</h2>
 
 <ul>
@@ -52,8 +62,14 @@ description: "Teaching portfolio in Virtual Reality, Augmented Reality, immersiv
   <li>Example topics: social acceptability in XR, QoE under network degradation, multimodal user-state assessment, and XR-based training concepts.</li>
 </ul>
 
+</div>
+
+<div class="section-block section-block--light">
+
 <h2>Current teaching entries</h2>
 
 {% for post in site.teaching reversed %}
   {% include archive-single.html hide_teaching_meta=true %}
 {% endfor %}
+
+</div>


### PR DESCRIPTION
### Motivation
- Bring the visual structure and hierarchy used on the About page to the rest of the main site so pages share a consistent, card-oriented design language.
- Reuse existing About-page components (cards, chips, affiliation box) to improve visual consistency without changing data logic.

### Description
- Ported the About page `section-block` pattern (alternating `section-block--white` / `section-block--light`) into the main pages to unify layout and block spacing across content. 
- Reused About-style components such as `affiliation-box`, `profile-links`/`profile-chip`, and `research-card` to render contact info, external profiles, projects, research lines, and FAQ entries consistently. 
- Preserved existing data-driven loops and interactive components (projects loop, publications filter loop, teaching entries, service lists) while reorganizing markup into styled blocks. 
- Files modified: `_pages/research.md`, `_pages/projects.md`, `_pages/contact.md`, `_pages/service.md`, `_pages/cv.md`, `_pages/faq.md`, `_pages/publications.html`, `_pages/teaching.html`, and `_pages/blog.md`.

### Testing
- Ran `git diff --check`, which reported no whitespace or index errors and succeeded. 
- Attempted `bundle exec jekyll build`, which failed because the `jekyll` executable is not available in the current environment. 
- Attempted `bundle install`, which failed due to HTTP 403 responses when fetching gems from RubyGems in this environment. 
- Attempted a Playwright screenshot of a local server at `http://127.0.0.1:4000/`, which failed because no local site server was running (Jekyll build/development server was not available).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4963fe06c83309c35a7d2c5a3de74)